### PR TITLE
melpa.milkbox.net is now melpa.org

### DIFF
--- a/alchemist.el
+++ b/alchemist.el
@@ -36,7 +36,7 @@
 ;;    or
 ;;
 ;;    (add-to-list 'package-archives
-;;                 '("melpa" . "http://melpa.milkbox.net/packages/") t)
+;;                 '("melpa" . "http://melpa.org/packages/") t)
 ;;
 ;;    M-x package-install alchemist
 


### PR DESCRIPTION
Melpa has been moved to melpa.org.

Thanks for the great work! I wish my lisp skills was better so I could help out with some actual code.
