### PR TITLE
Rather than have a special modeline element 

### DIFF
--- a/alchemist-buffer.el
+++ b/alchemist-buffer.el
@@ -33,7 +33,7 @@ changes depending on the success or failure of commands such as 'mix test'."
   :group 'alchemist-buffer)
 
 (defface alchemist-buffer--success-face
-  '((t (:inherit font-lock-variable-name-face :bold t :background "darkgreen" :foreground "white")))
+  '((t (:inherit font-lock-variable-name-face :bold t :background "darkgreen" :foreground "#e0ff00")))
   ""
   :group 'alchemist-buffer)
 


### PR DESCRIPTION
(which actually gets lost on my narrow display), change the face of the Elixir major mode itself.

To try this, run a mix command with some Elixir buffers visible. The mode name "Elixir" should change color in all buffers in Elixir mode.
