### PR TITLE
Variable For Iex Command Name

### DIFF
--- a/alchemist-iex.el
+++ b/alchemist-iex.el
@@ -32,8 +32,8 @@
   :prefix "alchemist-iex-"
   :group 'alchemist)
 
-(defcustom alchemist-iex-program-name "iex"
-  "The shell command for iex."
+(defvar alchemist-iex-program-name "iex"
+  "The shell command for iex. Default is iex"
   :type 'string
   :group 'alchemist-iex)
 


### PR DESCRIPTION
Modifying the code so that the iex command name can be specified via a variable.

When running under powershell on Windows, you need to specify the iex command as "iex.bat" because there is already an iex command built into powershell.  This change would simply allow a developer to change the name of the iex command if he or she needs to.  