### PR TITLE
Add functions to navigate between test and implementation

### DIFF
--- a/test/alchemist-project-test.el
+++ b/test/alchemist-project-test.el
@@ -64,6 +64,39 @@
    (f-touch "mix.exs")
    (should (equal (alchemist-project-name) "sandbox"))))
 
+(ert-deftest test-project-toggle/is-test-file-p ()
+  "Should return t if visited file is a test file"
+  (with-sandbox
+   (f-touch "this_is_a_test.exs")
+   (find-file "this_is_a_test.exs")
+   (should (alchemist--is-test-file-p))))
+
+(ert-deftest test-project-toggle/from-test-to-implementation ()
+  (with-sandbox
+   (f-touch "mix.exs")
+   (f-mkdir "lib" "path" "to")
+   (f-mkdir "test" "path" "to")
+   (f-touch "lib/path/to/file.ex")
+   (f-touch "test/path/to/file_test.exs")
+   (find-file "test/path/to/file_test.exs")
+
+   (alchemist-toggle-file-and-tests)
+   (should (equal (file-name-nondirectory (buffer-file-name))
+                  "file.ex"))))
+
+(ert-deftest test-project-toggle/from-implementation-to-test ()
+  (with-sandbox
+   (f-touch "mix.exs")
+   (f-mkdir "lib" "path" "to")
+   (f-mkdir "test" "path" "to")
+   (f-touch "lib/path/to/other_file.ex")
+   (f-touch "test/path/to/other_file_test.exs")
+
+   (find-file "lib/path/to/other_file.ex")
+   (alchemist-toggle-file-and-tests)
+   (should (equal (file-name-nondirectory (buffer-file-name))
+                  "other_file_test.exs"))))
+
 (ert-deftest test-project-config/return-config ()
   "Should return a hash-table with the config."
   (with-sandbox


### PR DESCRIPTION
This PR add functions that help with the navigation between files and their tests.

I have extended the existing `alchemist-project-open-tests-for-current-file` by allowing the user to choose whether to open the test file in the same window or in a new window.

I have added functionality to jump from the tests back to its corresponding file, also allowing one to control the window behavior.

(I don't thing `toggler` is a good name, but couldn't find a better one)

Closes #48 