### PR TITLE
Fix `alchemist-buffer--error-link-options` to match compilation errors

### DIFF
--- a/alchemist-buffer.el
+++ b/alchemist-buffer.el
@@ -50,7 +50,7 @@ formated with the `alchemist-buffer--failed-face' face, to symbolize failing tes
 (make-variable-buffer-local 'alchemist-buffer--buffer-name)
 
 (defvar alchemist-buffer--error-link-options
-  '(elixir "^\\([-A-Za-z0-9./_]+\\):\\([0-9]+\\)\\(: warning\\)?$" 1 2 nil (3) 1)
+  '(elixir "\\([-A-Za-z0-9./_]+\\):\\([0-9]+\\)\\(?: warning\\)?" 1 2 nil (3) 1)
   "File link matcher for `compilation-error-regexp-alist-alist' (matches path/to/file:line).")
 
 ;; Faces


### PR DESCRIPTION
This commit changes the word boundaries in the regexp
`alchemist-buffer--error-link-options`. This regexp is used to match
compilation errors in `mix-buffer`.

The previous value of `"^\\([-A-Za-z0-9./_]+\\):\\([0-9]+\\)\\(?:
warning\\)?$"` would not be able to match any of the errors in the
excerpt below:

```
  1) test can add to filter (BloomFilterTest)
     test/bloom_filter_test.exs:29
     ** (throw) :error
     stacktrace:
       (bloom_filter) lib/bloom_filter.ex:18: BloomFilter.test/2
       (elixir) lib/enum.ex:2139: Enum.do_all?/2
       test/bloom_filter_test.exs:35
```

With the new value of `"\\([-A-Za-z0-9./_]+\\):\\([0-9]+\\)\\(?:
warning\\)?"`, we have the following matches:

  - match: lib/bloom_filter.ex:18
    1st capture group: lib/bloom_filter.ex
    2nd capture group: 18

  - match: lib/enum.ex:2139
    1st capture group: lib/enum.ex
    2nd capture group: 2139

  - match: test/bloom_filter_test.exs:35
    1st capture group: test/bloom_filter_test.exs
    2nd capture group: 35

A better visualization made by using `regexp-builder` is provided below:
![screenshot from 2015-03-08 23 48 30](https://cloud.githubusercontent.com/assets/4231743/6549277/16c057fe-c5ef-11e4-8af4-f8651d10e168.png)

With this change, it is possible to follow the error corresponding
`lib/bloom_filter.ex` in the picture above.