### PR TITLE
Exclude pending tests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Example:
     </tr>
 </table>
 
+You can customize the default options passed to the `mix test` commands by
+customizing the value of the `alchemist-mix-test-default-options` variable.
 
 ## Compile And Execute
 

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -37,6 +37,11 @@
   :type 'string
   :group 'alchemist-mix)
 
+(defcustom alchemist-mix-test-default-options '("--exclude pending:true")
+  "Default options for alchemist test command."
+  :type 'list
+  :group 'alchemist-mix)
+
 (defvar alchemist-mix-buffer-name "*mix*"
   "Name of the mix output buffer.")
 
@@ -60,7 +65,7 @@
   "Run a specific FILENAME as argument for the mix command test."
   (when (not (file-exists-p filename))
     (error "The given file doesn't exists"))
-  (alchemist-mix-execute (list "test" (expand-file-name filename) "--exclude pending:true")))
+  (alchemist-mix-execute `("test" ,(expand-file-name filename) ,@alchemist-mix-test-default-options)))
 
 (defun alchemist-mix--commands ()
   (let ((mix-cmd-list (shell-command-to-string (format "%s help" alchemist-mix-command))))
@@ -84,7 +89,7 @@
 (defun alchemist-mix-test ()
   "Run the whole elixir test suite."
   (interactive)
-  (alchemist-mix-execute (list "test --exclude pending:true")))
+  (alchemist-mix-execute `("test" ,@alchemist-mix-test-default-options)))
 
 (defun alchemist-mix-test-this-buffer ()
   "Run the current buffer through mix test."

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -60,7 +60,7 @@
   "Run a specific FILENAME as argument for the mix command test."
   (when (not (file-exists-p filename))
     (error "The given file doesn't exists"))
-  (alchemist-mix-execute (list "test" (expand-file-name filename))))
+  (alchemist-mix-execute (list "test" (expand-file-name filename) "--exclude pending:true")))
 
 (defun alchemist-mix--commands ()
   (let ((mix-cmd-list (shell-command-to-string (format "%s help" alchemist-mix-command))))
@@ -84,7 +84,7 @@
 (defun alchemist-mix-test ()
   "Run the whole elixir test suite."
   (interactive)
-  (alchemist-mix-execute (list "test")))
+  (alchemist-mix-execute (list "test --exclude pending:true")))
 
 (defun alchemist-mix-test-this-buffer ()
   "Run the current buffer through mix test."

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -39,7 +39,7 @@
 
 (defcustom alchemist-mix-test-default-options '("--exclude pending:true")
   "Default options for alchemist test command."
-  :type 'list
+  :type '(repeat string)
   :group 'alchemist-mix)
 
 (defvar alchemist-mix-buffer-name "*mix*"


### PR DESCRIPTION
This PR adds "--exclude pending:true" to the test commands on the
whole suite and a single file. Always excluding what is marked as pending is what
makes most sense to me. That's the behaviour of `rspec` and `rspec-mode`.

I would like to hear others' opinions about this change.