### PR TITLE
Fix link to MELPA.stable in README.doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Alchemist comes with a bunch of features, which are:
 `package.el` is the built-in package manager in Emacs.
 
 Alchemist.el is available on the three major community maintained repositories -
-[MELPA STABLE](melpa-stable.milkbox.net), [MELPA](http://melpa.milkbox.net) and [Marmalade](https://marmalade-repo.org/).
+[MELPA STABLE](http://melpa-stable.milkbox.net), [MELPA](http://melpa.milkbox.net) and [Marmalade](https://marmalade-repo.org/).
 
 You can install `Alchemist` with the following commnad:
 


### PR DESCRIPTION
The link to MELPA.stable didn't include a protocol, so clicking it brought users to a bad location.