### PR TITLE
in some cases the etags library isn't loaded before using `find-tag-marker-ring`

### DIFF
--- a/alchemist-goto.el
+++ b/alchemist-goto.el
@@ -25,6 +25,8 @@
 
 ;;; Code:
 
+(require 'etags)
+
 (defgroup alchemist-goto nil
   "Functionality to jump modules and function definitions."
   :prefix "alchemist-goto-"


### PR DESCRIPTION
@sammyt could you test the `alchemist-goto-definition-at-point` with that branch please.