### PR TITLE
Make company-mode behavior changes buffer-local

### DIFF
--- a/alchemist-company.el
+++ b/alchemist-company.el
@@ -60,8 +60,6 @@
   (define-key company-active-map (kbd "C-w") 'alchemist-company--open-definition)
   (define-key company-active-map (kbd "M-.") 'alchemist-company--open-definition))
 
-(add-hook 'company-mode-hook 'alchemist-company--keybindings)
-
 (defun alchemist-company--annotation (candidate)
   (get-text-property 0 'meta candidate))
 
@@ -82,7 +80,11 @@
     (annotation (when alchemist-company-show-annotation
                   (alchemist-company--annotation arg)))))
 
-(add-to-list 'company-backends 'alchemist-company)
+(add-hook 'alchemist-mode-hook
+          (lambda ()
+            (make-local-variable 'company-active-map)
+            (alchemist-company--keybindings)
+            (setq-local company-backends (cons 'alchemist-company company-backends))))
 
 (provide 'alchemist-company)
 


### PR DESCRIPTION
I'm having problems with the modifications injected into company-mode by
alchemist. For example, I use <kbd>C-h</kbd> as `backward-delete-char`
instead of `help` and alchemist rebinds it to
`alchemist-company--show-documentation` which is definitely not what I
want when I'm writing code in other languages.

This commit tries to isolate the modifications provided by alchemist
only to buffers with `alchemist-mode` enabled by making use of
buffer-local variables.

I know very little about `company` and I'm not sure if this is the right
way to address the issue.