### PR TITLE
Add alchemist-test-mode-list-tests

### DIFF
--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -102,13 +102,8 @@ macro) while the values are the position at which the test matched."
         (while (re-search-forward alchemist-test-mode--test-regex nil t)
           (let* ((position (car (match-data)))
                  (matched-string (match-string 10)))
-<<<<<<< Updated upstream
-            (remove-text-properties 0 (- (length matched-string) 1) '(face nil) matched-string)
-            (add-to-list 'tests (cons matched-string position))))
-=======
             (set-text-properties 0 (length matched-string) nil matched-string)
             (add-to-list 'tests (cons matched-string position) t)))
->>>>>>> Stashed changes
         tests))))
 
 ;; Public functions

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -47,6 +47,7 @@ be highlighted with more significant font faces."
 (defvar alchemist-test-file #'alchemist-mix-test-file)
 (defvar alchemist-test-jump-to-previous-test #'alchemist-test-mode-jump-to-previous-test)
 (defvar alchemist-test-jump-to-next-test #'alchemist-test-mode-jump-to-next-test)
+(defvar alchemist-test-list-tests #'alchemist-test-mode-list-tests)
 
 (defvar alchemist-test-mode-map
   (let ((map (make-sparse-keymap)))
@@ -56,11 +57,17 @@ be highlighted with more significant font faces."
     (define-key map (kbd "C-c , f") alchemist-test-file)
     (define-key map (kbd "C-c , p") alchemist-test-jump-to-previous-test)
     (define-key map (kbd "C-c , n") alchemist-test-jump-to-next-test)
+    (define-key map (kbd "C-c , l") alchemist-test-list-tests)
     map)
   "Keymap for `alchemist-test-mode'.")
 
-(setq alchemist-test-mode--test-regex
-  "\\(^[[:space:]]*test .+ do[[:space:]]*$\\|^[[:space:]]* [0-9]+) test .+\\)")
+(let ((whitespace-opt "[[:space:]]*")
+      (whitespace "[[:space:]]+"))
+  (setq alchemist-test-mode--test-regex
+        (concat
+         "\\(^" whitespace-opt "test" whitespace "\\(?10:.+\\)" whitespace "do" whitespace-opt "$"
+         "\\|"
+         whitespace " [0-9]+) test .+\\)")))
 
 ;; Private functions
 
@@ -83,6 +90,21 @@ beginning/end of the buffer if no results were found)."
         (funcall search-fn alchemist-test-mode--test-regex nil t))
       (back-to-indentation))))
 
+(defun alchemist-test-mode--tests-in-buffer ()
+  "Return an alist of tests in this buffer.
+
+The keys in the list are the test names (e.g., the string passed to the test/2
+macro) while the values are the position at which the test matched."
+  (save-match-data
+    (save-excursion
+      (beginning-of-buffer)
+      (let ((tests '()))
+        (while (re-search-forward alchemist-test-mode--test-regex nil t)
+          (let ((position (car (match-data)))
+                (matched-string (match-string 10)))
+            (add-to-list 'tests (cons matched-string position))))
+        tests))))
+
 ;; Public functions
 
 (defun alchemist-test-mode-jump-to-next-test ()
@@ -99,6 +121,16 @@ in this buffer."
   (interactive)
   (alchemist-test-mode--jump-to-test 're-search-backward 'end-of-buffer))
 
+(defun alchemist-test-mode-list-tests ()
+  "List ExUnit tests (calls to the test/2 macro) in the current buffer and jump
+to the selected one."
+  (interactive)
+  (let* ((tests (alchemist-test-mode--tests-in-buffer))
+         (selected (completing-read "Test: " tests))
+         (position (cdr (assoc selected tests))))
+    (goto-char position)
+    (back-to-indentation)))
+
 (defun alchemist-test-mode--highlight-syntax ()
   (if alchemist-test-mode-highlight-tests
       (font-lock-add-keywords nil
@@ -108,6 +140,7 @@ in this buffer."
                                  font-lock-type-face t)
                                 ("^\s+\\(assert[_a-z]*\\|refute[_a-z]*\\)\(" 1
                                  font-lock-type-face t)))))
+
 
 ;;;###autoload
 (define-minor-mode alchemist-test-mode

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -100,9 +100,15 @@ macro) while the values are the position at which the test matched."
       (beginning-of-buffer)
       (let ((tests '()))
         (while (re-search-forward alchemist-test-mode--test-regex nil t)
-          (let ((position (car (match-data)))
-                (matched-string (match-string 10)))
+          (let* ((position (car (match-data)))
+                 (matched-string (match-string 10)))
+<<<<<<< Updated upstream
+            (remove-text-properties 0 (- (length matched-string) 1) '(face nil) matched-string)
             (add-to-list 'tests (cons matched-string position))))
+=======
+            (set-text-properties 0 (length matched-string) nil matched-string)
+            (add-to-list 'tests (cons matched-string position) t)))
+>>>>>>> Stashed changes
         tests))))
 
 ;; Public functions

--- a/test/alchemist-test-test.el
+++ b/test/alchemist-test-test.el
@@ -83,6 +83,21 @@ end
    (should (eq (alchemist-test-face-at 237) 'font-lock-type-face))
    (should (eq (alchemist-test-face-at 267) 'font-lock-variable-name-face))))
 
+(ert-deftest get-list-of-all-tests-in-buffer ()
+  (should (equal '("\"create a pkg file/dir skeleton\"" ":symbol")
+                 (with-temp-buffer
+                   (alchemist-test-mode)
+                   (insert "
+defmodule MyTest do
+  test \"create a pkg file/dir skeleton\" do
+  end
+
+  test :symbol do
+  end
+end
+")
+                   (mapcar 'car (alchemist-test-mode--tests-in-buffer))))))
+
 (provide 'alchemist-test-mode-test)
 
 ;;; alchemist-test-mode-test.el ends here


### PR DESCRIPTION
This function lists the tests in the current buffer (where "test" means call to the `test/2` macro from the ExUnit framework) and lets the user select a test and jump to it.

Screenshot of the usage with `helm-mode` enabled:

![screen shot 2015-06-22 at 23 30 39](https://cloud.githubusercontent.com/assets/3890250/8293581/c0ed11a0-1936-11e5-9484-0fd70872837d.png)

Todos:

- [x] Fix syntax highlighting
- [x] Force the order of the tests to be the order of the tests in the file, still not sure why this happens
- [x] Tests? :fearful: 

@tonini let me know what you think :).
