### PR TITLE
[WIP] alchemist-project-create-file

### DIFF
--- a/alchemist-project.el
+++ b/alchemist-project.el
@@ -152,7 +152,10 @@ The newly created buffer is filled with a module definition based on the file na
   (let ((root (alchemist-project-root)))
     (when root
       (let* ((module-name (alchemist-project--path-to-module-name relative-path))
-             (abs-path (concat root "lib/" relative-path)))
+             (abs-path (concat root "lib/" relative-path))
+             (abs-path (if (string-match-p "\.ex$" abs-path)
+                           abs-path
+                         (concat abs-path ".ex"))))
         (make-directory (file-name-directory abs-path) t)
         (find-file abs-path)
         (insert (concat "defmodule " module-name " do\n"

--- a/alchemist-project.el
+++ b/alchemist-project.el
@@ -144,26 +144,35 @@ Point is left in a convenient location."
          (path (mapcar (lambda (el) (replace-regexp-in-string "\.ex$" "" el)) path)))
     (mapconcat 'alchemist-project--underscore-to-camelcase path ".")))
 
-(defun alchemist-project-create-file (relative-path)
+(defun alchemist-project--maybe-add-file-extension-to-path (path)
+  (if (string-match-p "\.ex$" path)
+      path
+    (concat abs-path ".ex")))
+
+(defun alchemist-project-create-file ()
   "Create a file under lib/ in the current project.
 
 The newly created buffer is filled with a module definition based on the file name."
-  (interactive "sFile to create in lib/: ")
+  (interactive)
   (let ((root (alchemist-project-root)))
-    (when root
-      (let* ((module-name (alchemist-project--path-to-module-name relative-path))
-             (abs-path (concat root "lib/" relative-path))
-             (abs-path (if (string-match-p "\.ex$" abs-path)
-                           abs-path
-                         (concat abs-path ".ex"))))
-        (make-directory (file-name-directory abs-path) t)
-        (find-file abs-path)
-        (insert (concat "defmodule " module-name " do\n"
-                        "  \n"
-                        "end\n"))
-        (goto-char (point-min))
-        (beginning-of-line 2)
-        (back-to-indentation)))))
+    (if (not root)
+        (message "You're not in a Mix project")
+      (let* ((lib-path (concat root "lib/"))
+             (abs-path (read-file-name "New file in lib/: " lib-path))
+             (abs-path (alchemist-project--maybe-add-file-extension-to-path abs-path))
+             (relative-path (file-relative-name abs-path lib-path)))
+        (if (file-readable-p abs-path)
+            (message "%s already exists" relative-path)
+          (make-directory (file-name-directory abs-path) t)
+          (find-file abs-path)
+          (insert (concat "defmodule "
+                          (alchemist-project--path-to-module-name relative-path)
+                          " do\n"
+                          "  \n"
+                          "end\n"))
+          (goto-char (point-min))
+          (beginning-of-line 2)
+          (back-to-indentation))))))
 
 (defun alchemist-project-find-test ()
   "Open project test directory and list all test files."

--- a/alchemist-project.el
+++ b/alchemist-project.el
@@ -134,6 +134,34 @@ Point is left in a convenient location."
   (goto-char (point-min))
   (beginning-of-line 3))
 
+(defun alchemist-project--underscore-to-camelcase (string)
+  "Convert an underscore_string to a CamelCase string."
+  (mapconcat 'capitalize (split-string string "_") ""))
+
+(defun alchemist-project--path-to-module-name (path)
+  "Convert a `path' like my_lib/foo.ex to a module name like MyLib.Foo."
+  (let* ((path (split-string path "/"))
+         (path (mapcar (lambda (el) (replace-regexp-in-string "\.ex$" "" el)) path)))
+    (mapconcat 'alchemist-project--underscore-to-camelcase path ".")))
+
+(defun alchemist-project-create-file (relative-path)
+  "Create a file under lib/ in the current project.
+
+The newly created buffer is filled with a module definition based on the file name."
+  (interactive "sFile to create in lib/: ")
+  (let ((root (alchemist-project-root)))
+    (when root
+      (let* ((module-name (alchemist-project--path-to-module-name relative-path))
+             (abs-path (concat root "lib/" relative-path)))
+        (make-directory (file-name-directory abs-path) t)
+        (find-file abs-path)
+        (insert (concat "defmodule " module-name " do\n"
+                        "  \n"
+                        "end\n"))
+        (goto-char (point-min))
+        (beginning-of-line 2)
+        (back-to-indentation)))))
+
 (defun alchemist-project-find-test ()
   "Open project test directory and list all test files."
   (interactive)


### PR DESCRIPTION
This PR adds the `alchemist-project-create-file` function. Functions like `alchemist-project-toggle-file-and-tests` are incredibly useful to me when they create the missing test and fill in some details, but I often would like to do that with regular files as well :)

For example, say I'm in the "gettext" application, and I want to create `Gettext.Interpolation`. I have to manually `C-x C-f`, create the file `lib/gettext/interpolation.ex` (and all the directories if necessary), and fill it in with

```elixir
defmodule Gettext.Interpolation do
  # ...
end
```

The `alchemist-project-create-file` function aspires to ease out this process: it prompts for a file name (assumed to be under `lib/`) and it both creates that file and fills it in with the snippet of code above, inferring the module name from the file name. For example, passing `my_app/my_module.ex` to `alchemist-project-create-file` would result in the creation of `lib/my_app/my_module.ex`, with these contents:

```elixir
defmodule MyApp.MyModule do
  # <- cursor here
end
```

This is a WIP mainly because I don't know if @tonini likes this functionality and wants it in alchemist :), but also because there are still some rough edges:

- [ ] for now `interactive` uses the `s` control character, meaning it reads a string. I'd like to use `F` so that we have a nice file interface (which hooks up with helm and whatnot), completion and so on, but I need to figure out how to set the directory where to start (`lib/`).
- [x] make the `.ex` extension optional
- [ ] Tests? :partly_sunny: