### PR TITLE
Add alchemist-project-run-tests-for-current-file

### DIFF
--- a/alchemist-project.el
+++ b/alchemist-project.el
@@ -149,6 +149,11 @@ Point is left in a convenient location."
       path
     (concat abs-path ".ex")))
 
+(defun alchemist-project-run-tests-for-current-file ()
+  "Run the tests related to the current file."
+  (interactive)
+  (alchemist--project-open-tests-for-current-file 'alchemist-mix-test-file))
+
 (defun alchemist-project-create-file ()
   "Create a file under lib/ in the current project.
 

--- a/alchemist.el
+++ b/alchemist.el
@@ -116,6 +116,7 @@ Key bindings:
   (define-key map (kbd "p f") 'alchemist-project-find-test)
   (define-key map (kbd "p s") 'alchemist-project-toggle-file-and-tests)
   (define-key map (kbd "p o") 'alchemist-project-toggle-file-and-tests-other-window)
+  (define-key map (kbd "p t") 'alchemist-project-run-tests-for-current-file)
   (define-key map (kbd "i i") 'alchemist-iex-run)
   (define-key map (kbd "i p") 'alchemist-iex-project-run)
   (define-key map (kbd "i l") 'alchemist-iex-send-current-line)


### PR DESCRIPTION
I felt the need for such a function multiple times when using Alchemist. Basically, I'm in a file and I'm testing it continuously: switching to the test file (even if it's a `C-c a p s` away) just for running `alchemist-mix-test-this-buffer` is annoying.

This function provides a way to run the tests associated with this file. The implementation is trivial as it just calls `alchemist--project-open-tests-for-current-file` passing `alchemist-mix-test-file` as a "toggler" function.

I bound this function to the `C-c a p t` keys but please, feel free to change it into anything you find more appropriate. Btw, I wasn't sure if this function belonged to `alchemist-project` or `alchemist-mix`, if you think `alchemist-mix` would have been a more appropriate fit let me know and I'll move it.

Wdyt, @tonini?