### PR TITLE
Document the need for trailing slashes in source directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ By default you're able to jump to definitions of your own mix project codebase a
 But if you would like to also jump to Elixir and Erlang source code you need to tell Alchemist where
 it can find the source code of Elixir and Erlang.
 
-For that purpose there're two variables you can set:
+For that purpose there're two variables you can set (trailing slashes are required):
 
 ```el
 (setq alchemist-goto-erlang-source-dir "/path/to/erlang/source/")


### PR DESCRIPTION
I fought a little with jump to source, until realizing that the trailing slash is required on the path to sources.