### PR TITLE
Add alchemist-mix-rerun-last-test

### DIFF
--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -86,8 +86,20 @@ not set explicitly."
   "Run a specific FILENAME as argument for the mix command test."
   (when (not (file-exists-p filename))
     (error "The given file doesn't exists"))
+  (setq alchemist-last-run-test (expand-file-name filename))
   (alchemist-mix-execute `(,alchemist-mix-test-task ,(expand-file-name filename) ,@alchemist-mix-test-default-options)
                          alchemist-test-mode-buffer-name))
+
+(defun alchemist-mix-rerun-last-test ()
+  "Rerun the last test that was run by alchemist.
+
+When no tests had been run before calling this function, do nothing."
+  (interactive)
+  (if alchemist-last-run-test
+      (alchemist-mix-execute
+       `(,alchemist-mix-test-task ,alchemist-last-run-test ,@alchemist-mix-test-default-options)
+       alchemist-test-mode-buffer-name)
+    (message "No tests have been run yet")))
 
 (defun alchemist-mix--commands ()
   (let ((mix-cmd-list (shell-command-to-string (format "%s help" alchemist-mix-command))))
@@ -112,6 +124,7 @@ not set explicitly."
 (defun alchemist-mix-test ()
   "Run the whole elixir test suite."
   (interactive)
+  (setq alchemist-last-run-test "")
   (alchemist-mix-execute `(,alchemist-mix-test-task ,@alchemist-mix-test-default-options)
                          alchemist-test-mode-buffer-name))
 
@@ -130,6 +143,7 @@ not set explicitly."
   (interactive)
   (let* ((line (line-number-at-pos (point)))
          (file-and-line (format "%s:%s" buffer-file-name line)))
+    (setq alchemist-last-run-test file-and-line)
     (alchemist-mix-execute (list alchemist-mix-test-task file-and-line)
                            alchemist-test-mode-buffer-name)))
 

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -38,6 +38,7 @@
 ;; Variables
 
 (defvar alchemist-test-mode-buffer-name "")
+(defvar alchemist-last-run-test nil)
 
 (defcustom alchemist-mix-command "mix"
   "The shell command for mix."

--- a/alchemist.el
+++ b/alchemist.el
@@ -89,6 +89,7 @@ Key bindings:
 (let ((map alchemist-mode-keymap))
   (define-key map (kbd "x") 'alchemist-mix)
   (define-key map (kbd "t") 'alchemist-mix-test)
+  (define-key map (kbd "r") 'alchemist-mix-rerun-last-test)
   (define-key map (kbd "m c") 'alchemist-mix-compile)
   (define-key map (kbd "m t f") 'alchemist-mix-test-file)
   (define-key map (kbd "m t b") 'alchemist-mix-test-this-buffer)

--- a/test/alchemist-mix-test.el
+++ b/test/alchemist-mix-test.el
@@ -34,6 +34,7 @@
   (cd "test/dummy_elixir/test/")
   (shut-up
     (alchemist-mix-test))
+  (should (equal "" alchemist-last-run-test))
   (delay 1.2 (lambda ()
                (should (alchemist-buffer--last-run-successful-p)))))
 
@@ -45,6 +46,7 @@
     (shut-up
       (goto-line 5)
       (alchemist-mix-test-at-point)))
+  (should (equal (expand-file-name "dummy_elixir_test.exs:5") alchemist-last-run-test))
   (delay 1.2 (lambda ()
                (should (alchemist-buffer--last-run-successful-p)))))
 
@@ -53,6 +55,7 @@
   (cd "test/dummy_elixir/test/")
   (shut-up
     (alchemist-mix-test-file "dummy_elixir_test.exs"))
+  (should (equal (expand-file-name "dummy_elixir_test.exs") alchemist-last-run-test))
   (delay 1.2 (lambda ()
                (should (alchemist-buffer--last-run-successful-p)))))
 


### PR DESCRIPTION
I love this functionality when I'm working so I thought I'd give it a shot.

Basically, I want a quick way to rerun the last test I run through alchemist. Say I'm working on a unit test, and I'm using `alchemist-mix-test-at-point` to run the test. I change to the code, edit it, then I have to go back to the test (and *inside the test*, again) to rerun `alchemist-mix-test-at-point`. With `alchemist-mix-rerun-last-test`, I can just do `alchemist-mix-test-at-point` and then use `alchemist-mix-rerun-last-test` to rerun the test (until I run another test obviously).

The way it works now it's pretty simple: I set an `alchemist-last-run-test` global variable each time a test function is run (`alchemist-mix-test`, `alchemist-mix-test-file` and so on), then I look up that variable in `alchemist-mix-rerun-last-test` to rerun the last test.

It's a WIP since:

- [x] as usual, I don't know if @tonini is interested in the feature :)
- [x] it has no keybinding yet
- [x] with some refactoring of the functions in `alchemist-mix` the implementation could me more straightforward, but maybe that belongs to another PR

Let me know what you think!