### PR TITLE
alchemist-utils--regex-in-buffer-p

### DIFF
--- a/alchemist-goto.el
+++ b/alchemist-goto.el
@@ -246,10 +246,7 @@ It will jump to the position of the symbol definition after selection."
          (replace-regexp-in-string ",?\s+do:.*$" "" (replace-regexp-in-string "\s+do$" "" arguments)))))))
 
 (defun alchemist-goto--file-contains-defs-p ()
-  (save-excursion
-    (save-match-data
-      (goto-char (point-min))
-      (re-search-forward alchemist-goto--symbol-def-extract-regex nil t))))
+  (alchemist-utils--regex-in-buffer-p (current-buffer) alchemist-goto--symbol-def-extract-regex))
 
 (defun alchemist-goto-jump-to-next-def-symbol ()
   (interactive)

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -72,10 +72,7 @@ be highlighted with more significant font faces."
 
 (defun alchemist-test-mode--buffer-contains-tests-p ()
   "Return nil if the current buffer contains no tests, non-nil if it does."
-  (save-excursion
-    (save-match-data
-      (goto-char (point-min))
-      (re-search-forward alchemist-test-mode--test-regex nil t))))
+  (alchemist-utils--regex-in-buffer-p (current-buffer) alchemist-test-mode--test-regex))
 
 (defun alchemist-test-mode--jump-to-test (search-fn reset-fn)
   "Move the point to the next/previous test, based on `search-fn' (which is the

--- a/alchemist-utils.el
+++ b/alchemist-utils.el
@@ -138,6 +138,15 @@ For example, convert 'my_app/my_module.ex' to 'MyApp.MyModule'."
       (format "%s/" path)
     path))
 
+(defun alchemist-utils--regex-in-buffer-p (buffer regex)
+  "Return non-nil if the given `BUFFER' contains at least one occurrence of
+  `REGEX', nil otherwise."
+  (with-current-buffer buffer
+    (save-excursion
+      (save-match-data
+        (beginning-of-buffer)
+        (re-search-forward regex nil t)))))
+
 (provide 'alchemist-utils)
 
 ;;; alchemist-utils.el ends here

--- a/alchemist-utils.el
+++ b/alchemist-utils.el
@@ -144,7 +144,7 @@ For example, convert 'my_app/my_module.ex' to 'MyApp.MyModule'."
   (with-current-buffer buffer
     (save-excursion
       (save-match-data
-        (beginning-of-buffer)
+        (goto-char (point-min))
         (re-search-forward regex nil t)))))
 
 (provide 'alchemist-utils)

--- a/test/alchemist-utils-test.el
+++ b/test/alchemist-utils-test.el
@@ -117,6 +117,13 @@ a text")))
   (should (equal "/path/to/some/thing/" (alchemist-utils--add-trailing-slash "/path/to/some/thing")))
   (should (equal "/path/to/some/thing/" (alchemist-utils--add-trailing-slash "/path/to/some/thing/"))))
 
+(ert-deftest test-utils/regex-in-buffer-p ()
+  (with-temp-buffer
+    (insert "1 2 3 foo 4 5 6")
+    (end-of-buffer)
+    (should (alchemist-utils--regex-in-buffer-p (current-buffer) "f[oO]o"))
+    (should (not (alchemist-utils--regex-in-buffer-p (current-buffer) "bar")))))
+
 (provide 'alchemist-utils-tests)
 
 ;;; alchemist-utils-tests.el ends here


### PR DESCRIPTION
I added this function (with tests :tada:) because we were duplicating this logic in two places (`alchemist-test-mode--file-contains-tests-p` and `alchemist-goto--file-contains-defs-p`). Both these function now use `alchemist-utils--regex-in-buffer-p`.