### PR TITLE
"Jump to regex" refactorings

### DIFF
--- a/alchemist-goto.el
+++ b/alchemist-goto.el
@@ -250,23 +250,11 @@ It will jump to the position of the symbol definition after selection."
 
 (defun alchemist-goto-jump-to-next-def-symbol ()
   (interactive)
-  (when (alchemist-goto--file-contains-defs-p)
-    (save-match-data
-      (end-of-line) ;; otherwise we could match on the current line and stay there forever
-      (unless (re-search-forward alchemist-goto--symbol-def-regex nil t)
-      (goto-char (point-min))
-        (re-search-forward alchemist-goto--symbol-def-regex nil t))
-      (back-to-indentation))))
+  (alchemist-utils--jump-to-next-matching-line alchemist-goto--symbol-def-regex 'back-to-indentation))
 
 (defun alchemist-goto-jump-to-previous-def-symbol ()
   (interactive)
-  (when (alchemist-goto--file-contains-defs-p)
-    (save-match-data
-      (beginning-of-line) ;; otherwise we could match on the current line and stay there forever
-      (unless (re-search-backward alchemist-goto--symbol-def-regex nil t)
-        (goto-char (point-max))
-        (re-search-backward alchemist-goto--symbol-def-regex nil t))
-      (back-to-indentation))))
+  (alchemist-utils--jump-to-previous-matching-line alchemist-goto--symbol-def-regex 'back-to-indentation))
 
 (defun alchemist-goto--extract-symbol-bare (str)
   (save-match-data

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -74,18 +74,6 @@ be highlighted with more significant font faces."
   "Return nil if the current buffer contains no tests, non-nil if it does."
   (alchemist-utils--regex-in-buffer-p (current-buffer) alchemist-test-mode--test-regex))
 
-(defun alchemist-test-mode--jump-to-test (search-fn reset-fn)
-  "Move the point to the next/previous test, based on `search-fn' (which is the
-function that searches for the next test, can be re-search-forward or
-re-search-backward) and `reset-fn' (which is used when wrapping at the
-beginning/end of the buffer if no results were found)."
-  (when (alchemist-test-mode--buffer-contains-tests-p)
-    (save-match-data
-      (unless (funcall search-fn alchemist-test-mode--test-regex nil t)
-        (funcall reset-fn)
-        (funcall search-fn alchemist-test-mode--test-regex nil t))
-      (back-to-indentation))))
-
 (defun alchemist-test-mode--tests-in-buffer ()
   "Return an alist of tests in this buffer.
 
@@ -109,14 +97,14 @@ macro) while the values are the position at which the test matched."
 position, jump to the first test in the buffer. Do nothing if there are no tests
 in this buffer."
   (interactive)
-  (alchemist-test-mode--jump-to-test 're-search-forward 'beginning-of-buffer))
+  (alchemist-utils--jump-to-next-matching-line alchemist-test-mode--test-regex 'back-to-indentation))
 
 (defun alchemist-test-mode-jump-to-previous-test ()
   "Jump to the previous ExUnit test. If there are no tests before the current
 position, jump to the last test in the buffer. Do nothing if there are no tests
 in this buffer."
   (interactive)
-  (alchemist-test-mode--jump-to-test 're-search-backward 'end-of-buffer))
+  (alchemist-utils--jump-to-previous-matching-line alchemist-test-mode--test-regex 'back-to-indentation))
 
 (defun alchemist-test-mode-list-tests ()
   "List ExUnit tests (calls to the test/2 macro) in the current buffer and jump

--- a/alchemist-utils.el
+++ b/alchemist-utils.el
@@ -147,6 +147,32 @@ For example, convert 'my_app/my_module.ex' to 'MyApp.MyModule'."
         (goto-char (point-min))
         (re-search-forward regex nil t)))))
 
+(defun alchemist-utils--jump-to-regex (regex before-fn after-fn search-fn reset-fn)
+  "Jump to `REGEX' using `SEARCH-FN' to search for it.
+
+A common use case would be to use 're-search-forward' as the `SEARCH-FN'. Call
+`RESET-FN' if the regex isn't found at the first try. `BEFORE-FN' is called
+before performing the search while `AFTER-FN' after."
+  (when (alchemist-utils--regex-in-buffer-p (current-buffer) regex)
+    (save-match-data
+      (funcall before-fn)
+      (unless (funcall search-fn regex nil t)
+        (funcall reset-fn)
+        (funcall search-fn regex nil t))
+      (funcall after-fn))))
+
+(defun alchemist-utils--jump-to-next-matching-line (regex after-fn)
+  "Jump to the next line matching `REGEX'.
+
+Call `AFTER-FN' after performing the search (for example, you could use back-to-indentation to go back to the indentation after the search."
+  (alchemist-utils--jump-to-regex regex 'end-of-line after-fn 're-search-forward 'beginning-of-buffer))
+
+(defun alchemist-utils--jump-to-previous-matching-line (regex after-fn)
+  "Jump to the previous line matching `REGEX'.
+
+Call `AFTER-FN' after performing the search (for example, you could use back-to-indentation to go back to the indentation after the search."
+  (alchemist-utils--jump-to-regex regex 'beginning-of-line after-fn 're-search-backward 'end-of-buffer))
+
 (provide 'alchemist-utils)
 
 ;;; alchemist-utils.el ends here

--- a/test/alchemist-utils-test.el
+++ b/test/alchemist-utils-test.el
@@ -124,6 +124,32 @@ a text")))
     (should (alchemist-utils--regex-in-buffer-p (current-buffer) "f[oO]o"))
     (should (not (alchemist-utils--regex-in-buffer-p (current-buffer) "bar")))))
 
+(ert-deftest test-utils/jump-to-next-matching-line ()
+  (with-temp-buffer
+    (insert "
+foo
+bar
+foo
+")
+    (alchemist-utils--jump-to-next-matching-line "foo" 'beginning-of-line)
+    (should (equal (point) 2))
+    (alchemist-utils--jump-to-next-matching-line "foo" 'beginning-of-line)
+    (should (equal (point) 10))
+    (alchemist-utils--jump-to-next-matching-line "foo" 'beginning-of-line)
+    (should (equal (point) 2))))
+
+(ert-deftest test-utils/jump-to-previous-regex ()
+  (with-temp-buffer
+    (insert "
+foo
+bar
+foo
+")
+    (alchemist-utils--jump-to-previous-matching-line "foo" 'beginning-of-line)
+    (should (equal (point) 10))
+    (alchemist-utils--jump-to-previous-matching-line "foo" 'beginning-of-line)
+    (should (equal (point) 2))))
+
 (provide 'alchemist-utils-tests)
 
 ;;; alchemist-utils-tests.el ends here


### PR DESCRIPTION
I added `alchemist-utils--jump-to-next-matching-line` and `alchemist-utils--jump-to-previous-matching-line` (with tests :D) and used them to refactor things here and there.