### PR TITLE
added keybinding for refcard+a mention in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ installed on the system, the documentation you get by `alchemist` is the same
 |<kbd>C-c a h i</kbd>| Look through search history. `alchemist-help-history` |
 |<kbd>C-c a h e</kbd>| Run `alchemist-help` with the expression under the cursor. (example: `is_binary`  or `Code.eval_string`). `alchemist-help-search-at-point`              |
 |<kbd>C-c a h m</kbd>| Run `alchemist-help` with the current marked region. `alchemist-help-search-marked-region`|
+|<kbd>C-c a h r</kbd>| Open a buffer with a refcard of alchemist bindings. `alchemist-refcard`|
 
 ### Alchemist Help Minor Mode Keymap
 

--- a/alchemist-refcard.el
+++ b/alchemist-refcard.el
@@ -88,6 +88,7 @@
                     (alchemist-refcard--build-tabulated-row "alchemist-help-history")
                     (alchemist-refcard--build-tabulated-row "alchemist-help-search-at-point")
                     (alchemist-refcard--build-tabulated-row "alchemist-help-search-marked-region")
+                    (alchemist-refcard--build-tabulated-row "alchemist-refcard")
                     (alchemist-refcard--build-empty-tabulated-row)
                     (alchemist-refcard--build-tabulated-title-row "Definition Lookup")
                     (alchemist-refcard--build-tabulated-row "alchemist-goto-definition-at-point")

--- a/alchemist.el
+++ b/alchemist.el
@@ -106,6 +106,7 @@ Key bindings:
   (define-key map (kbd "h i") 'alchemist-help-history)
   (define-key map (kbd "h e") 'alchemist-help-search-at-point)
   (define-key map (kbd "h m") 'alchemist-help-search-marked-region)
+  (define-key map (kbd "h r") 'alchemist-refcard)
   (define-key map (kbd "p f") 'alchemist-project-find-test)
   (define-key map (kbd "p s") 'alchemist-project-toggle-file-and-tests)
   (define-key map (kbd "p o") 'alchemist-project-toggle-file-and-tests-other-window)

--- a/doc/alchemist-refcard.tex
+++ b/doc/alchemist-refcard.tex
@@ -84,6 +84,7 @@
 \key{C-c a h i}{alchemist-help-history}
 \key{C-c a h e}{alchemist-help-search-at-point}
 \key{C-c a h m}{alchemist-help-search-marked-region}
+\key{C-c a h r}{alchemist-refcard}
 
 \group{Definition Lookup}
 


### PR DESCRIPTION
I thought that a keybinding for alchemist-refcard was missing, so I added one:

  * Added a `C-c a h r` keybinding to alchemist-refcard
  * Updated the project README
  * Updated the tex help file (but not the pdf output, sorry)
  * Updated the refcard to mention it self

I don't know if the mentions about alchemist-refcard belongs in the alchemist-help section, but I've put it there. Any suggestions? I think the `h r` binding seems reasonable.