### PR TITLE
make alchemist-company only in elixir-mode.

### DIFF
--- a/alchemist.el
+++ b/alchemist.el
@@ -214,7 +214,10 @@ Key bindings:
      ["Documentation search marked region..." alchemist-help-search-marked-region])
     ))
 
-(add-hook 'elixir-mode-hook 'alchemist-mode-hook)
+(add-hook 'elixir-mode-hook
+          (lambda ()
+            (add-to-list (make-local-variable 'company-backends)
+                         'alchemist-company)))
 
 (provide 'alchemist)
 


### PR DESCRIPTION
add alchemist-company to global `company-backends` list is not a good idea.
make it local to elixir-mode or leave it to user, not global by default.