### PR TITLE
add a region/non-region aware help-search function

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,7 @@ installed on the system, the documentation you get by `alchemist` is the same
 |------------|-------------------------------------------------|
 |<kbd>C-c a h h</kbd>| Run a custom search. `alchemist-help`              |
 |<kbd>C-c a h i</kbd>| Look through search history. `alchemist-help-history` |
-|<kbd>C-c a h e</kbd>| Run `alchemist-help` with the expression under the cursor. (example: `is_binary`  or `Code.eval_string`). `alchemist-help-search-at-point`              |
-|<kbd>C-c a h m</kbd>| Run `alchemist-help` with the current marked region. `alchemist-help-search-marked-region`|
+|<kbd>C-c a h e</kbd>| Run `alchemist-help` with the expression under the cursor. (example: `is_binary`  or `Code.eval_string`). If there is a currently marked region this will be used as the search term `alchemist-help-search-at-point`              |
 |<kbd>C-c a h r</kbd>| Open a buffer with a refcard of alchemist bindings. `alchemist-refcard`|
 
 ### Alchemist Help Minor Mode Keymap

--- a/alchemist-help.el
+++ b/alchemist-help.el
@@ -120,8 +120,6 @@
            "]-quit ["
            (propertize "e" 'face 'alchemist-help--key-face)
            "]-search-at-point ["
-           (propertize "m" 'face 'alchemist-help--key-face)
-           "]-search-marked-region ["
            (propertize "s" 'face 'alchemist-help--key-face)
            "]-search ["
            (propertize "h" 'face 'alchemist-help--key-face)
@@ -130,8 +128,15 @@
            "]-keys")))
 
 (defun alchemist-help-search-at-point ()
-  "Search through `alchemist-help' with the expression under the cursor."
+  "Search through `alchemist-help' with the expression under the cursor,
+or the actively marked region."
   (interactive)
+  (if mark-active
+      (alchemist-help--search-marked-region (region-beginning) (region-end))
+      (alchemist-help--search-at-point)))
+
+(defun alchemist-help--search-at-point ()
+  "Search through `alchemist-help' with the expression under the cursor"
   (let* ((expr (alchemist-help--exp-at-point))
          (module (alchemist-goto--extract-module expr))
          (module (alchemist-goto--get-full-path-of-alias module))
@@ -148,7 +153,7 @@
                  expr))))
     (alchemist-help--execute expr)))
 
-(defun alchemist-help-search-marked-region (begin end)
+(defun alchemist-help--search-marked-region (begin end)
   "Run `alchemist-help' with the marked region.
 Argument BEGIN where the mark starts.
 Argument END where the mark ends."
@@ -183,7 +188,6 @@ Argument END where the mark ends."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") #'quit-window)
     (define-key map (kbd "e") #'alchemist-help-search-at-point)
-    (define-key map (kbd "m") #'alchemist-help-search-marked-region)
     (define-key map (kbd "s") #'alchemist-help)
     (define-key map (kbd "h") #'alchemist-help-history)
     (define-key map (kbd "M-.") #'alchemist-goto-definition-at-point)
@@ -207,6 +211,10 @@ Argument END where the mark ends."
    (list
     (completing-read "Elixir help history: " alchemist-help-search-history nil nil "")))
   (alchemist-help--execute-without-complete search))
+
+;; Deprecated functions; these will get removed in v1.5.0
+(defun alchemist-help-search-marked-region () (interactive)
+       (alchemist-utils-deprecated-message "alchemist-help-search-marked-region" "alchemist-help-search-at-point"))
 
 (provide 'alchemist-help)
 

--- a/alchemist-refcard.el
+++ b/alchemist-refcard.el
@@ -88,7 +88,6 @@
                     (alchemist-refcard--build-tabulated-row "alchemist-help")
                     (alchemist-refcard--build-tabulated-row "alchemist-help-history")
                     (alchemist-refcard--build-tabulated-row "alchemist-help-search-at-point")
-                    (alchemist-refcard--build-tabulated-row "alchemist-help-search-marked-region")
                     (alchemist-refcard--build-tabulated-row "alchemist-refcard")
                     (alchemist-refcard--build-empty-tabulated-row)
                     (alchemist-refcard--build-tabulated-title-row "Definition Lookup")

--- a/doc/alchemist-refcard.tex
+++ b/doc/alchemist-refcard.tex
@@ -84,7 +84,6 @@
 \key{C-c a h h}{alchemist-help}
 \key{C-c a h i}{alchemist-help-history}
 \key{C-c a h e}{alchemist-help-search-at-point}
-\key{C-c a h m}{alchemist-help-search-marked-region}
 \key{C-c a h r}{alchemist-refcard}
 
 \group{Definition Lookup}


### PR DESCRIPTION
* Made the `alchemist-help-search-at-point` use the marked region as search term if set, otherwise it will use the word beneath the cursor.
* Deprecated the `C-c a h m` keybinding.
* Updated the README.
* Updated the Refcard.
* Updated the tex-file (but did not produce a new pdf-file, sorry).
* The old `alchemist-help-search-marked-region` is now a private helper function.