### PR TITLE
Change some defvars into defconsts

### DIFF
--- a/alchemist-goto.el
+++ b/alchemist-goto.el
@@ -227,9 +227,9 @@ It will jump to the position of the symbol definition after selection."
 (defun alchemist-goto--fetch-symbol-definitions ()
   (alchemist-goto--search-for-symbols "^\\s-*\\(defp?\\|defmacrop?\\|defmodule\\)\s.*"))
 
-(defvar alchemist-goto--symbol-def-extract-regex
+(defconst alchemist-goto--symbol-def-extract-regex
   "^\\s-*\\(defp?\\|defmacrop?\\|defmodule\\)[ \n\t]+\\([a-z_\?!]+\\)\\(.*\\)\\(do\\|\n\\)?$")
-(defvar alchemist-goto--symbol-def-regex
+(defconst alchemist-goto--symbol-def-regex
   "^[[:space:]]*\\(defmodule\\|defmacrop?\\|defp?\\)")
 
 (defun alchemist-goto--extract-symbol (str)

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -59,8 +59,10 @@ Otherwise, it saves all modified buffers without asking."
 (defvar alchemist-test-report-buffer-name "*alchemist-test-report*"
   "Name of the test report buffer.")
 
-(defvar alchemist-test--failing-files-regex "\\(  [0-9]+).+\n\s+\\)\\([-A-Za-z0-9./_]+:[0-9]+\\)$")
-(defvar alchemist-test--stacktrace-files-regex "\\(       \\)\\([-A-Za-z0-9./_]+:[0-9]+\\).*")
+(defconst alchemist-test--failing-files-regex
+  "\\(  [0-9]+).+\n\s+\\)\\([-A-Za-z0-9./_]+:[0-9]+\\)$")
+(defconst alchemist-test--stacktrace-files-regex
+  "\\(       \\)\\([-A-Za-z0-9./_]+:[0-9]+\\).*")
 
 ;; Faces
 
@@ -116,7 +118,7 @@ Otherwise, it saves all modified buffers without asking."
     map)
   "Keymap for `alchemist-test-mode'.")
 
-(defvar alchemist-test-mode--test-regex
+(defconst alchemist-test-mode--test-regex
   (let ((whitespace-opt "[[:space:]]*")
         (whitespace "[[:space:]]+"))
     (concat "\\(^" whitespace-opt "test" whitespace "\\(?10:.+\\)" whitespace "do" whitespace-opt "$"


### PR DESCRIPTION
Just a little experiment to see if @tonini is interested in this. I think a lot of the `defvar`s in alchemist could be replaced by `defconst` (the regexes I changed are a good example I think). Let me know what you think!