### PR TITLE
Binding for alchemist-execute is wrong in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ The Mix tasks running in a separate `alchemist-mix-mode`, in which the following
 |-------------------|-------------|
 |<kbd>C-c a e b</kbd>|Run the current buffer through `elixir` command. `alchemist-execute-this-buffer`|
 |<kbd>C-c a e f</kbd>|Run `elixir` command with the given `FILENAME`. `alchemist-execute-file` |
-|<kbd>C-c a e c</kbd>|Run a custom execute command with `elixir`. `alchemist-execute` |
+|<kbd>C-c a e e</kbd>|Run a custom execute command with `elixir`. `alchemist-execute` |
 
 ## Project
 


### PR DESCRIPTION
I made a mistake in #146, and this is the fix.
