### PR TITLE
A quick hack to close the alchemist-refcard buffer with q

### DIFF
--- a/alchemist-refcard.el
+++ b/alchemist-refcard.el
@@ -50,6 +50,7 @@
 (defvar alchemist-refcard-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "i") 'alchemist-refcard--describe-funtion-at-point)
+    (define-key map (kbd "q") 'quit-window)
     map)
   "Keymap for `alchemist-refcard-mode'.")
 


### PR DESCRIPTION
A quick _hack_ to close the `alchemist-refcard` buffer with `q`.
This _hack_ was *not tested*!!!