### PR TITLE
Add IRC notifications to the travis-ci setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ install:
   - cask install
 script:
   - make
+notifications:
+  irc: "irc.freenode.org#emacs-elixir"


### PR DESCRIPTION
As we talked about on the #emacs-elixir irc channel on freenode.

This should make travis-ci post to the channel when it is running.