### PR TITLE
Implementation/test toggle for Phoenix directory structure

### DIFF
--- a/alchemist-project.el
+++ b/alchemist-project.el
@@ -89,16 +89,27 @@ directory from there instead."
 
 (defun alchemist--project-open-file-for-current-tests (toggler)
   "Open the appropriate implementation file for the current buffer by calling TOGGLER with filename."
+  (let* ((filename (alchemist--project-filename-for-current-tests "web/"))
+         (filename
+          (if (file-exists-p filename)
+              filename
+            (alchemist--project-filename-for-current-tests "lib/"))))
+    (funcall toggler filename))
+  )
+
+(defun alchemist--project-filename-for-current-tests (base-dir)
+  "Generates filename for implementation file in project root BASE-DIR."
   (let* ((filename (file-relative-name (buffer-file-name) (alchemist-project-root)))
-         (filename (replace-regexp-in-string "^test/" "lib/" filename))
+         (filename (replace-regexp-in-string "^test/" base-dir filename))
          (filename (replace-regexp-in-string "_test\.exs$" "\.ex" filename))
          (filename (format "%s/%s" (alchemist-project-root) filename)))
-    (funcall toggler filename)))
+    filename))
 
 (defun alchemist--project-open-tests-for-current-file (toggler)
   "Opens the appropriate test file by calling TOGGLER with filename."
   (let* ((filename (file-relative-name (buffer-file-name) (alchemist-project-root)))
          (filename (replace-regexp-in-string "^lib/" "test/" filename))
+         (filename (replace-regexp-in-string "^web/" "test/" filename))
          (filename (replace-regexp-in-string "\.ex$" "_test\.exs" filename))
          (filename (format "%s/%s" (alchemist-project-root) filename)))
     (if (file-exists-p filename)

--- a/test/alchemist-project-test.el
+++ b/test/alchemist-project-test.el
@@ -74,8 +74,21 @@
    (find-file "test/path/to/file_test.exs")
 
    (alchemist-project-toggle-file-and-tests)
-   (should (equal (file-name-nondirectory (buffer-file-name))
-                  "file.ex"))))
+   (should (string-match "lib/path/to/file.ex"
+                         (buffer-file-name)))))
+
+(ert-deftest test-project-toggle/from-test-to-implementation/with_web_dir ()
+  (with-sandbox
+   (f-touch "mix.exs")
+   (f-mkdir "web" "path" "to")
+   (f-mkdir "test" "path" "to")
+   (f-touch "web/path/to/web_file.ex")
+   (f-touch "test/path/to/web_file_test.exs")
+   (find-file "test/path/to/web_file_test.exs")
+
+   (alchemist-project-toggle-file-and-tests)
+   (should (string-match "web/path/to/web_file.ex"
+                         (buffer-file-name)))))
 
 (ert-deftest test-project-toggle/from-implementation-to-test ()
   (with-sandbox
@@ -87,8 +100,21 @@
 
    (find-file "lib/path/to/other_file.ex")
    (alchemist-project-toggle-file-and-tests)
-   (should (equal (file-name-nondirectory (buffer-file-name))
-                  "other_file_test.exs"))))
+   (should (string-match "test/path/to/other_file_test.exs"
+                         (buffer-file-name)))))
+
+(ert-deftest test-project-toggle/from-implementation-to-test/with-web-dir ()
+  (with-sandbox
+   (f-touch "mix.exs")
+   (f-mkdir "web" "path" "to")
+   (f-mkdir "test" "path" "to")
+   (f-touch "web/path/to/web_other_file.ex")
+   (f-touch "test/path/to/web_other_file_test.exs")
+
+   (find-file "web/path/to/web_other_file.ex")
+   (alchemist-project-toggle-file-and-tests)
+   (should (string-match "test/path/to/web_other_file_test.exs"
+                         (buffer-file-name)))))
 
 (ert-deftest test-project-find-files-in-directory ()
   (with-sandbox


### PR DESCRIPTION
When switching from impl <-> test, phoenix directory structure with
`web/` is also considered.

When switching impl -> test, `^web/` is also stripped from impl
directory. When switching test -> impl, existence of impl file within
`web/` folder is checked first. If none found, file within `lib/` folder is
returned.