### PR TITLE
Add a "recompile" binding for alchemist-test-report

### DIFF
--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -109,6 +109,7 @@ Otherwise, it saves all modified buffers without asking."
 (defvar alchemist-test-report-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "q" #'quit-window)
+    (define-key map "g" #'alchemist-mix-rerun-last-test)
     (define-key map (kbd "M-n") #'alchemist-test-next-result)
     (define-key map (kbd "M-p") #'alchemist-test-previous-result)
     (define-key map (kbd "M-N") #'alchemist-test-next-stacktrace-file)


### PR DESCRIPTION
Its very common in compilation-like buffers to have a "recompile"
command bound to the "g" key.

This commit adds such functionality by binding
`alchemist-mix-rerun-last-test` to the `g` key in `alchemist-test-report-mode`