### PR TITLE
Quote shell arguments for alchemists-server

### DIFF
--- a/alchemist-server.el
+++ b/alchemist-server.el
@@ -84,7 +84,9 @@ An Alchemist server will be started for the current Elixir mix project."
          (default-directory (if (string= process-name "alchemist-server")
                                 default-directory
                               process-name))
-         (server-command (format "elixir %s %s" alchemist-server env))
+         (server-command (format "elixir %s %s"
+                                 (shell-quote-argument alchemist-server)
+                                 (shell-quote-argument env)))
          (process (start-process-shell-command process-name "*alchemist-server*" server-command)))
     (set-process-query-on-exit-flag process nil)
     (alchemist-server--store-process process)))


### PR DESCRIPTION
If the alchemist-server path contained spaces (as it does in Aquamacs),
the server would not be able to start as the path argument would end at
the space. This change simply calls shell-quote-argument which escapes
the spaces.