### PR TITLE
Add optional mix compile after save hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ through the variable.
 (setq alchemist-hooks-test-on-save t)
 ```
 
+* Compile your project with `alchemist-mix-compile` after saving a buffer.
+
+```el
+(setq alchemist-hooks-compile-on-save t)
+```
+
 ## Server
 
 Alchemist works as a server & client model, where the Alchemist server is written in Elixir and Emacs takes the part of the client.

--- a/alchemist-hooks.el
+++ b/alchemist-hooks.el
@@ -41,6 +41,11 @@
   :type 'boolean
   :group 'alchemist-hooks)
 
+(defcustom alchemist-hooks-compile-on-save nil
+  "If t, run `alchemist-mix-compile' on save."
+  :type 'boolean
+  :group 'alchemist-hooks)
+
 (defun alchemist-hooks-test-on-save ()
   (when (and alchemist-hooks-test-on-save
              (alchemist-project-p))
@@ -51,9 +56,20 @@
                           #'alchemist-test--handle-exit
                           t)))
 
+(defun alchemist-hooks-compile-on-save ()
+  (when (and alchemist-hooks-compile-on-save
+             (alchemist-project-p))
+    (alchemist-report-run "mix compile"
+                          alchemist-mix-process-name
+                          alchemist-mix-buffer-name
+                          #'alchemist-mix-mode
+                          nil
+                          t)))
+
 (eval-after-load 'elixir-mode
   '(progn
-     (add-hook 'after-save-hook 'alchemist-hooks-test-on-save nil nil)))
+     (add-hook 'after-save-hook 'alchemist-hooks-test-on-save nil nil)
+     (add-hook 'after-save-hook 'alchemist-hooks-compile-on-save nil nil)))
 
 (provide 'alchemist-hooks)
 

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -73,6 +73,9 @@ not set explicitly."
 (defvar alchemist-mix--envs '("dev" "prod" "test")
   "The list of mix envs to use as defaults.")
 
+(defconst alchemist-mix-process-name "alchemist-mix-report"
+  "Name of the mix process.")
+
 ;; Private functions
 
 (defun alchemist-mix--completing-read (prompt cmdlist)
@@ -220,7 +223,7 @@ If PREFIX is non-nil, prompt for a mix environment variable."
          (command (alchemist-utils-build-command
                    (list (when mix-env (concat "MIX_ENV=" mix-env))
                          alchemist-mix-command command-list))))
-    (alchemist-report-run command "alchemist-mix-report" alchemist-mix-buffer-name 'alchemist-mix-mode)))
+    (alchemist-report-run command alchemist-mix-process-name alchemist-mix-buffer-name 'alchemist-mix-mode)))
 
 (provide 'alchemist-mix)
 


### PR DESCRIPTION
This change adds a similar option to test-on-save but will compile instead. This is especially useful if you have a code reloader for your project.