### PR TITLE
Module names start with A-Z and can contain digits

### DIFF
--- a/alchemist-scope.el
+++ b/alchemist-scope.el
@@ -32,7 +32,7 @@
   :prefix "alchemist-scope-"
   :group 'alchemist)
 
-(defconst alchemist-scope-defmodule-regex "defmodule \\([A-Za-z\._]+\\)\s+"
+(defconst alchemist-scope-defmodule-regex "defmodule \\([A-Z][A-Za-z0-9\._]+\\)\s+"
   "The regex for matching Elixir defmodule macro.")
 
 (defconst alchemist-scope-alias-regex


### PR DESCRIPTION
The regex `alchemist-scope-defmodule-regex` used for finding module names
does not allow digits in the names and it does not enforce a capital letter
at the beginning of the module name. This new definition does so.

Fixes #226.