### PR TITLE
Fix company-mode recursion in alchemist-iex-mode

### DIFF
--- a/alchemist-iex.el
+++ b/alchemist-iex.el
@@ -68,12 +68,6 @@ iex(1)>
     (define-key map (kbd "M-.") 'alchemist-goto-definition-at-point)
     map))
 
-(eval-after-load 'company
-  '(progn
-     (defun alchemist-iex--set-company-as-completion-at-point-function ()
-       (setq completion-at-point-functions '(company-complete)))
-     (add-hook 'alchemist-iex-mode-hook 'alchemist-iex--set-company-as-completion-at-point-function)))
-
 (define-derived-mode alchemist-iex-mode comint-mode "Alchemist-IEx"
   "Major mode for interacting with an Elixir IEx process.
 


### PR DESCRIPTION
Setting the completion-at-point-functions to '(company-complete) makes company-mode unusable(freeze in infinite recursion) in alchemist-iex-mode buffers(at least for me:p).