### PR TITLE
Use path to '_build/dev' as default directory for BEAM files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,16 @@ otp_release:
   - 18.0
 cache: apt
 env:
-  - EVM_EMACS=emacs-24.4-bin
-  - EVM_EMACS=emacs-24.5-bin
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
 before_install:
-  - curl -fsSkL https://gist.githubusercontent.com/tonini/09a8bec7a0b2c219e0d7/raw > travis.sh && source ./travis.sh
+  - curl -fsSkL https://gist.githubusercontent.com/tonini/74a12bfd4f99e872385de6ea0bc39700/raw > x.sh && source ./x.sh
   - evm install $EVM_EMACS --use --skip
-  - cask
+  - cask --debug
 install:
   - cask install
 script:
+  - emacs --version
   - make
 notifications:
   irc: "irc.freenode.org#emacs-elixir"

--- a/alchemist-iex.el
+++ b/alchemist-iex.el
@@ -150,7 +150,10 @@ and jump to the buffer."
 (defun alchemist-iex-compile-this-buffer ()
   "Compiles the current buffer in the IEx process."
   (interactive)
-  (let ((str (format "c(\"%s\")" (buffer-file-name))))
+  (let* ((path (if (alchemist-project-p)
+		   (format "%s/_build/dev/" (alchemist-project-root))
+		 "."))
+	 (str (format "c(\"%s\", %s)" (buffer-file-name) path)))
     (alchemist-iex--send-command (alchemist-iex-process) str)))
 
 (defun alchemist-iex-reload-module ()


### PR DESCRIPTION
> At the moment, the best way to recompile a given file into your alchemist iex session is alchemist-iex-compile-this-buffer, which works, but leaves .beam files in your current working directory. IEx.Helpers.c/2 takes a path, so I assume we could specify the existing build path if there is one. 

Fixed with this `PR`

> Alternatively, or perhaps additionally, an easy recompile/0 hook would be nice so that after making a change I could force a recompile for my mix project.
Even more fancy would be automatic detection of writes to files and automatic recompilation, though this can perhaps be handled by things like sync and remix

We have a run compilation function if you use the `compile after save` hook -> http://alchemist.readthedocs.io/en/latest/configuration/#hooks

Or you can always run `alchemist-mix-compile` by hand to compile the whole mix project.

fixes #228

/cc @aaronjensen 
