### PR TITLE
Add function to compile buffer in iex and go

### DIFF
--- a/alchemist-iex.el
+++ b/alchemist-iex.el
@@ -151,6 +151,12 @@ and jump to the buffer."
 	 (str (format "c(\"%s\", \"%s\")" (buffer-file-name) path)))
     (alchemist-iex--send-command (alchemist-iex-process) str)))
 
+(defun alchemist-iex-compile-this-buffer-and-go ()
+  "Compiles the current buffer in the IEx process and jump to the buffer."
+  (interactive)
+  (alchemist-iex-compile-this-buffer)
+  (pop-to-buffer (process-buffer (alchemist-iex-process))))
+
 (defun alchemist-iex-reload-module ()
   "Recompiles and reloads the current module in the IEx process."
   (interactive)


### PR DESCRIPTION
Introduces `alchemist-iex-compile-this-buffer-and-go`, to compile the current buffer in iex and immediately jump to iex.

(I found myself reaching for functionality similar to `alchemist-iex-send-current-line-and-go` and
`alchemist-iex-send-region-and-go`, but for the whole buffer.)

``` el
;; alchemist-iex.el L154-L158 (21d87f06)

(defun alchemist-iex-compile-this-buffer-and-go ()
  "Compiles the current buffer in the IEx process and jump to the buffer."
  (interactive)
  (alchemist-iex-compile-this-buffer)
  (pop-to-buffer (process-buffer (alchemist-iex-process))))
```

<sup>[[source](https://github.com/jkrmr/alchemist.el/blob/21d87f06/alchemist-iex.el#L154-L158)]</sup>
