### PR TITLE
Add support for mix test --stale

### DIFF
--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -122,6 +122,11 @@ executed, gets called."
   (interactive)
   (alchemist-mix--execute-test))
 
+(defun alchemist-mix-test-stale ()
+  "Run stale tests (Elixir 1.3+ only)."
+  (interactive)
+  (alchemist-mix--execute-test "--stale"))
+
 (defun alchemist-mix-test-this-buffer ()
   "Run the current buffer through mix test."
   (interactive)

--- a/test/alchemist-mix-test.el
+++ b/test/alchemist-mix-test.el
@@ -47,6 +47,15 @@
   (delay 1.2 (lambda ()
                (should (alchemist-test--last-run-successful-p)))))
 
+(ert-deftest test-mix/run-mix-test-stale ()
+  (prepare-test-report-buffer)
+  (cd "test/dummy_elixir/test/")
+  (shut-up
+   (alchemist-mix-test-stale))
+  (should (equal "--stale" alchemist-last-run-test))
+  (delay 1.2 (lambda ()
+               (should (alchemist-test--last-run-successful-p)))))
+
 (provide 'alchemist-mix-test)
 
 ;;; alchemist-goto-test.el ends here


### PR DESCRIPTION
Currently test is failing with:

```

Clean *.elc files:

rm -f *.elc
/Applications/Xcode.app/Contents/Developer/usr/bin/make unit

Run tests:

cask exec ert-runner
Elixir 1.3.3
......................................................Test test-mix/run-mix-test-stale backtrace:

  (setq value-578 (apply fn-576 args-577))
  (unwind-protect (setq value-578 (apply fn-576 args-577)) (setq form-
  (if (unwind-protect (setq value-578 (apply fn-576 args-577)) (setq f
  (let (form-description-580) (if (unwind-protect (setq value-578 (app
  (let ((value-578 (quote ert-form-evaluation-aborted-579))) (let (for
  (let ((fn-576 (function alchemist-test--last-run-successful-p)) (arg
  (closure (t) nil (let ((fn-576 (function alchemist-test--last-run-su
  apply((closure (t) nil (let ((fn-576 (function alchemist-test--last-
  timer-event-handler([t 22570 51441 727395 nil (closure (t) nil (let
  sleep-for(1)
  sit-for(1)
  (progn (interrupt-process process) (sit-for 1) (delete-process proce
  (condition-case nil (progn (interrupt-process process) (sit-for 1) (
  (if (or (not (eq (process-status process) (quote run))) (eq (process
  (let* ((mode-name (if (stringp mode-name) (replace-regexp-in-string
  (save-current-buffer (set-buffer (process-buffer process)) (let* ((m
  (progn (save-current-buffer (set-buffer (process-buffer process)) (l
  (if process (progn (save-current-buffer (set-buffer (process-buffer
  alchemist-report--kill-process(#<process alchemist-test-process>)
  (let* ((buffer (get-buffer-create buffer-name)) (default-directory (
  alchemist-report-run("mix test --stale" "alchemist-test-process" "*a
  (let* ((command (mapconcat (quote concat) (-flatten command-list) "
  alchemist-test-execute(("mix" "test" "--stale" nil))
  alchemist-mix--execute-test("--stale")
  alchemist-mix-test-stale()
  (progn (fset (quote load) (function shut-up-load)) (fset (quote writ
  (unwind-protect (progn (fset (quote load) (function shut-up-load)) (
  (let* ((vnew (function (lambda (char) (shut-up-insert-to-buffer char
  (unwind-protect (let* ((vnew (function (lambda (char) (shut-up-inser
  (if shut-up-ignore (progn (alchemist-mix-test-stale)) (unwind-protec
  (let (--cl-shut-up-current-output--) (setq --cl-shut-up-current-outp
  (let ((shut-up-sink (generate-new-buffer " *shutup*")) (inhibit-mess
  (closure (t) nil (prepare-test-report-buffer) (cd "test/dummy_elixir
  ert--run-test-internal([cl-struct-ert--test-execution-info [cl-struc
  ert-run-test([cl-struct-ert-test test-mix/run-mix-test-stale nil (cl
  ert-run-or-rerun-test([cl-struct-ert--stats (and t) [[cl-struct-ert-
  ert-run-tests((and t) (lambda (event-type &rest event-args) (cond ((
  ert-runner/run-tests-batch((and t))
  (let ((stats (ert-runner/run-tests-batch selector))) (kill-emacs (if
  ert-runner/run-tests-batch-and-exit((and t))
  (progn (fset (quote load) (function shut-up-load)) (fset (quote writ
  (unwind-protect (progn (fset (quote load) (function shut-up-load)) (
  (let* ((vnew (function (lambda (char) (shut-up-insert-to-buffer char
  (unwind-protect (let* ((vnew (function (lambda (char) (shut-up-inser
  (if shut-up-ignore (progn (ert-runner/run-tests-batch-and-exit ert-r
  (let (--cl-shut-up-current-output--) (setq --cl-shut-up-current-outp
  (let ((shut-up-sink (generate-new-buffer " *shutup*")) (inhibit-mess
  (if ert-runner-verbose (ert-runner/run-tests-batch-and-exit ert-runn
  (let ((test-files (ert-runner--test-files tests)) (test-helper (f-ex
  ert-runner/run()
  apply(ert-runner/run nil)
  commander--handle-command(nil)
  commander-parse(nil)
  (if commander-parsing-done nil (commander-parse (or commander-args (
  eval-buffer(#<buffer  *load*> nil "/Users/chris/dev/elixir/alchemist
  load-with-code-conversion("/Users/chris/dev/elixir/alchemist.el/.cas
  load("/Users/chris/dev/elixir/alchemist.el/.cask/25.1.1/elpa/ert-run
  command-line-1(("-scriptload" "/Users/chris/dev/elixir/alchemist.el/
  command-line()
  normal-top-level()

Test test-mix/run-mix-test-stale condition:

    (void-function alchemist-test--last-run-successful-p)

F.............................

Ran 84 tests in 23.334 seconds
1 unexpected results:
   FAILED  test-mix/run-mix-test-stale
make[1]: *** [unit] Error 1
make: *** [test] Error 2
```

And I don't know enough to debug it.