### PR TITLE
Add support for mix test --stale

### DIFF
--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -122,6 +122,11 @@ executed, gets called."
   (interactive)
   (alchemist-mix--execute-test))
 
+(defun alchemist-mix-test-stale ()
+  "Run stale tests (Elixir 1.3+ only)."
+  (interactive)
+  (alchemist-mix--execute-test "--stale"))
+
 (defun alchemist-mix-test-this-buffer ()
   "Run the current buffer through mix test."
   (interactive)

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -125,7 +125,10 @@ executed, gets called."
 (defun alchemist-mix-test-stale ()
   "Run stale tests (Elixir 1.3+ only)."
   (interactive)
-  (alchemist-mix--execute-test "--stale"))
+  (if (alchemist-utils-elixir-version-check-p 1 3 0)
+      (alchemist-mix--execute-test "--stale")
+    (progn (message "Elixir needs to be >= 1.3.0 for mix test --stale")
+           (alchemist-mix-test))))
 
 (defun alchemist-mix-test-this-buffer ()
   "Run the current buffer through mix test."

--- a/alchemist-refcard.el
+++ b/alchemist-refcard.el
@@ -91,6 +91,7 @@
                     (alchemist-refcard--build-tabulated-row "alchemist-mix-test-file")
                     (alchemist-refcard--build-tabulated-row "alchemist-mix-test-this-buffer")
                     (alchemist-refcard--build-tabulated-row "alchemist-mix-test-at-point")
+                    (alchemist-refcard--build-tabulated-row "alchemist-mix-test-stale")
                     (alchemist-refcard--build-tabulated-row "alchemist-test-toggle-test-report-display")
                     (alchemist-refcard--build-empty-tabulated-row)
                     (alchemist-refcard--build-tabulated-title-row "Compilation")

--- a/alchemist-utils.el
+++ b/alchemist-utils.el
@@ -146,6 +146,19 @@ Call AFTER-FN after performing the search."
          (version (replace-regexp-in-string "Elixir " "" version)))
     version))
 
+(defun alchemist-utils-elixir-version-check-p (major minor tiny &optional version)
+  "Returns t if the current elixir version is greater than or equal to the supplied version"
+  (let* ((version-string (or version (alchemist-utils-elixir-version)))
+         (version-list (split-string version-string "\\."))
+         (current-major (string-to-number (car version-list)))
+         (current-minor (string-to-number (car (cdr version-list))))
+         (current-tiny (string-to-number (car (cdr (cdr version-list))))))
+    (if (> current-major major)
+        t
+      (if (and (= current-major major) (> current-minor minor))
+          t
+        (and (= current-minor minor) (>= current-tiny tiny))))))
+
 (provide 'alchemist-utils)
 
 ;;; alchemist-utils.el ends here

--- a/alchemist.el
+++ b/alchemist.el
@@ -136,6 +136,7 @@ Key bindings:
   (define-key map (kbd "m t f") 'alchemist-mix-test-file)
   (define-key map (kbd "m t b") 'alchemist-mix-test-this-buffer)
   (define-key map (kbd "m t .") 'alchemist-mix-test-at-point)
+  (define-key map (kbd "m t s") 'alchemist-mix-test-stale)
 
   (define-key map (kbd "c c") 'alchemist-compile)
   (define-key map (kbd "c f") 'alchemist-compile-file)
@@ -253,6 +254,7 @@ Key bindings:
      ["Mix test this buffer" alchemist-mix-test-this-buffer]
      ["Mix test file..." alchemist-mix-test-file]
      ["Mix test at point" alchemist-mix-test-at-point]
+     ["Mix run stale tests (Elixir 1.3+)" alchemist-mix-test-stale]
      "---"
      ["Mix..." alchemist-mix]
      "---"

--- a/doc/alchemist-refcard.tex
+++ b/doc/alchemist-refcard.tex
@@ -68,6 +68,7 @@
 \key{C-c a m t f}{alchemist-mix-test-file}
 \key{C-c a m t b}{alchemist-mix-test-this-buffer}
 \key{C-c a m t .}{alchemist-mix-test-at-point}
+\key{C-c a m t s}{alchemist-mix-test-stale}
 \key{C-c M-r}{alchemist-test-toggle-test-report-display}
 
 \group{Compilation}

--- a/doc/basic_usage.md
+++ b/doc/basic_usage.md
@@ -39,6 +39,7 @@ The Mix tasks running in a separate `alchemist-mix-mode`, in which the following
 |<kbd>C-c a m t f</kbd>|Run `alchemist-mix--test-file` with the FILENAME. `alchemist-mix-test-file`|
 |<kbd>C-c a m t b</kbd>|Run the current buffer through mix test. `alchemist-mix-test-this-buffer`|
 |<kbd>C-c a m t .</kbd>|Run the test at point. `alchemist-mix-test-at-point`|
+|<kbd>C-c a m t s</kbd>|Run only stale tests (Elixir 1.3+). `alchemist-mix-test-stale` |
 |<kbd>C-c M-r</kbd>|Toggle between displaying or hidding the test report buffer. `alchemist-test-toggle-test-report-display`|
 
 ## Compile And Execute

--- a/test/alchemist-mix-test.el
+++ b/test/alchemist-mix-test.el
@@ -35,9 +35,9 @@
   (shut-up
     (alchemist-mix-test))
   (should (equal "" alchemist-last-run-test))
-  (delay 1.2 (lambda ()
+  (delay 2.0 (lambda ()
                (should (alchemist-report--last-run-successful-p))))
-  (wait 1.3))
+  (wait 2.1))
 
 (ert-deftest test-mix/run-mix-test-file ()
   (prepare-test-report-buffer)
@@ -45,9 +45,9 @@
   (shut-up
     (alchemist-mix-test-file "dummy_elixir_test.exs"))
   (should (equal (expand-file-name "dummy_elixir_test.exs") alchemist-last-run-test))
-  (delay 1.2 (lambda ()
+  (delay 2.0 (lambda ()
                (should (alchemist-report--last-run-successful-p))))
-  (wait 1.3))
+  (wait 2.1))
 
 (ert-deftest test-mix/run-mix-test-stale ()
   (prepare-test-report-buffer)
@@ -58,9 +58,9 @@
   (if (alchemist-utils-elixir-version-check-p 1 3 0)
       (should (equal "--stale" alchemist-last-run-test))
     (should (equal "" alchemist-last-run-test)))
-  (delay 1.2 (lambda ()
+  (delay 2.1 (lambda ()
                (should (alchemist-report--last-run-successful-p))))
-  (wait 1.3))
+  (wait 2.1))
 
 (provide 'alchemist-mix-test)
 

--- a/test/alchemist-mix-test.el
+++ b/test/alchemist-mix-test.el
@@ -54,7 +54,10 @@
   (cd "test/dummy_elixir/test/")
   (shut-up
    (alchemist-mix-test-stale))
-  (should (equal "--stale" alchemist-last-run-test))
+  ;; CI runs multiple elixir versions so check correct version here
+  (if (alchemist-utils-elixir-version-check-p 1 3 0)
+      (should (equal "--stale" alchemist-last-run-test))
+    (should (equal "" alchemist-last-run-test)))
   (delay 1.2 (lambda ()
                (should (alchemist-report--last-run-successful-p))))
   (wait 1.3))

--- a/test/alchemist-mix-test.el
+++ b/test/alchemist-mix-test.el
@@ -36,7 +36,8 @@
     (alchemist-mix-test))
   (should (equal "" alchemist-last-run-test))
   (delay 1.2 (lambda ()
-               (should (alchemist-test--last-run-successful-p)))))
+               (should (alchemist-report--last-run-successful-p))))
+  (wait 1.3))
 
 (ert-deftest test-mix/run-mix-test-file ()
   (prepare-test-report-buffer)
@@ -45,7 +46,18 @@
     (alchemist-mix-test-file "dummy_elixir_test.exs"))
   (should (equal (expand-file-name "dummy_elixir_test.exs") alchemist-last-run-test))
   (delay 1.2 (lambda ()
-               (should (alchemist-test--last-run-successful-p)))))
+               (should (alchemist-report--last-run-successful-p))))
+  (wait 1.3))
+
+(ert-deftest test-mix/run-mix-test-stale ()
+  (prepare-test-report-buffer)
+  (cd "test/dummy_elixir/test/")
+  (shut-up
+   (alchemist-mix-test-stale))
+  (should (equal "--stale" alchemist-last-run-test))
+  (delay 1.2 (lambda ()
+               (should (alchemist-report--last-run-successful-p))))
+  (wait 1.3))
 
 (provide 'alchemist-mix-test)
 

--- a/test/alchemist-utils-test.el
+++ b/test/alchemist-utils-test.el
@@ -130,6 +130,13 @@ foo
   (should (string-match-p "^[0-9]+\.[0-9]+\.[0-9]+.*$"
                           (alchemist-utils-elixir-version))))
 
+(ert-deftest test-utils/elixir-version-check-p ()
+  (should (alchemist-utils-elixir-version-check-p 1 3 0 "1.3.0"))
+  (should-not (alchemist-utils-elixir-version-check-p 1 3 1 "1.3.0"))
+  (should-not (alchemist-utils-elixir-version-check-p 1 3 0 "1.2.9"))
+  (should-not (alchemist-utils-elixir-version-check-p 2 0 0 "1.3.0"))
+  (should (alchemist-utils-elixir-version-check-p 1 3 0 "2.0.0")))
+
 (provide 'alchemist-utils-tests)
 
 ;;; alchemist-utils-tests.el ends here


### PR DESCRIPTION
This PR adds support for `mix test --stale` when Elixir is 1.3+. For earlier versions it displays a message and runs tests normally.

Also fixes problem with existing alchemist-mix tests not waiting until delay finished before exiting.