### PR TITLE
Fix `alchemist-test-{next,previous}-result` in test report

### DIFF
--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -70,9 +70,9 @@ Otherwise, it saves all modified buffers without asking."
   "Name of the test report process.")
 
 (defconst alchemist-test--failing-files-regex
-  "\\(  [0-9]+).+\n\s+\\)\\([-A-Za-z0-9./_]+:[0-9]+\\)$")
+  "\\( *[0-9]+).+\n\s+\\)\\([-A-Za-z0-9./_]+:[0-9]+\\)$")
 (defconst alchemist-test--stacktrace-files-regex
-  "\\(       \\)\\([-A-Za-z0-9./_]+:[0-9]+\\).*")
+  "\\( *\\)\\([-A-Za-z0-9./_]+:[0-9]+\\): (test)")
 
 ;; Faces
 


### PR DESCRIPTION
When calling `alchemist-test-{next,previous}-result` with more than 10 test
failures, the jump cycles through failures 1-9. This happens because the regex that matches
the errors consider a fixed number of spaces which are not the same after the 10th error.

This commit changes the regexp to allow jumping through all test errors