### PR TITLE
Bugfix: Handle aliases with `{}` notation in mixed order

### DIFF
--- a/alchemist-scope.el
+++ b/alchemist-scope.el
@@ -110,7 +110,10 @@
                    (as (if (match-string 3) (match-string 3) nil))
                    (as (if as as (car (last (split-string alias "\\."))))))
               (setq aliases (append aliases (list (list (alchemist-utils-remove-dot-at-the-end alias)
-                                                        (alchemist-utils-remove-dot-at-the-end as))))))))
+                                                        (alchemist-utils-remove-dot-at-the-end as))))))))))
+    (save-excursion
+      (when (alchemist-scope-inside-module-p)
+        (end-of-line)
         ;; alias definition like:
         ;;
         ;;   alias List.Chars.{Atom, Float}

--- a/test/alchemist-scope-test.el
+++ b/test/alchemist-scope-test.el
@@ -125,6 +125,8 @@ end")
                    (alchemist-scope-aliases))))
   (should (equal (list '("Phoenix.Router.Scope" "Scope")
                        '("Phoenix.Router.Resource" "Special")
+                       '("List.Chars.BitString" "BitString")
+                       '("List.Chars.Integer" "Integer")
                        '("List.Chars.Atom" "Atom")
                        '("List.Chars.Float" "Float"))
                  (with-temp-buffer
@@ -134,6 +136,7 @@ defmodule Phoenix.Router do
 
   alias List.Chars.{Atom, Float}
   alias Phoenix.Router.Resource, as: Special
+  alias List.Chars.{BitString, Integer}
   alias Phoenix.Router.Scope
 
 end")


### PR DESCRIPTION
Previously `alchemist-scope-aliases` would only recognize all aliases when the
ones declared with the `{}` where declared strictly before the normal ones.

See `test/alchemist-scope-test.el` for a failing test case.

That happened because both searches where happening inside the same
`save-excursion` block.

This commit fixes that bug and now allows aliases declared in both ways to be
mixed in any order.