### PR TITLE
Add Elixir 1.4.0 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: elixir
 elixir:
   - 1.2.6
   - 1.3.4
+  - 1.4.0
 otp_release:
   - 18.0
   - 19.0


### PR DESCRIPTION
Travis may not yet support 1.4.0, but it's worth trying. Their docs
are sparse (https://docs.travis-ci.com/user/languages/elixir/).

On my machine with Elixir 1.4.0 there's currently one failing test:

    1 unexpected results:
       FAILED  alchemist-company-test/module-alias-aware