### PR TITLE
feature/goto-definition-prompts-for-empty-scope

### DIFF
--- a/alchemist-goto.el
+++ b/alchemist-goto.el
@@ -288,7 +288,11 @@ It will jump to the position of the symbol definition after selection."
 (defun alchemist-goto-definition-at-point ()
   "Jump to the elixir expression definition at point."
   (interactive)
-  (alchemist-goto--open-definition (alchemist-scope-expression)))
+  (alchemist-goto--open-definition
+   (let ((scope (alchemist-scope-expression)))
+     (if (string-equal "" scope)
+         (read-from-minibuffer "Find definition: ")
+       scope))))
 
 (defalias 'alchemist-goto-jump-back 'pop-tag-mark)
 


### PR DESCRIPTION
Hi,

I have a small change here for ```alchemist-goto-definition-at-point```. If no scope can be found, i.e. if ```(alchemist-scope-expression)``` returns ```""```, the user is prompted in the minibuffer.

The rationale for this is that sometimes I would like to jump to a definition that is not written somewhere in the current buffer. So instead of writing this into the buffer in order to be able to jump there, I would prefer to write it into the minibuffer.

Could you help to make this pull request even nicer?

- please comment on how I changed ```alchemist-goto--open-definition```. Should I do something differently?
- Is there a way to ask for the definition in the minibuffer with completion support? I think this would be even better.