### PR TITLE
Fixing docstring documentation not found

### DIFF
--- a/alchemist-utils.el
+++ b/alchemist-utils.el
@@ -55,8 +55,7 @@
 (defun alchemist-utils-empty-string-p (string)
   "Return non-nil if STRING is null, blank or whitespace only."
   (or (null string)
-      (string= string "")
-      (if (string-match-p "^\s+$" string) t)))
+      (string= string "")))
 
 (defun alchemist-utils-prepare-aliases-for-elixir (aliases)
   (let* ((aliases (-map (lambda (a)


### PR DESCRIPTION
This fixed the "No documentation for XXX found", when in fact the documentation exists in some rare cases.

There is a problem inside the function alchemist-utils-empty-string-p: The regex for checking an input of only spaces "^\s+$" is WRONG if there is just ONE line that is empty it matches:

ELISP> (string-match-p "^\s+$" "     \nx\n     x")
0 (#o0, #x0, ?\C-@) ; wrong
ELISP> (string-match-p "^\s+$" "121sdfadf")
nil
The result in both cases should nil. I don't know how to regex multiple lines in emacs. So my solution is to simplily remove that string-match-p.