### PR TITLE
Fix alchemist-phoenix for new phoenix structure (#306)

### DIFF
--- a/alchemist-phoenix.el
+++ b/alchemist-phoenix.el
@@ -37,7 +37,8 @@
 (defun alchemist-phoenix-project-p ()
   "Return non-nil if `default-directory' is inside a Phoenix project."
   (and (alchemist-project-p)
-       (file-directory-p (concat (alchemist-project-root) "web"))))
+       (file-directory-p (concat (alchemist-project-root) "lib/" (alchemist-app-name) "_web"))
+       (file-directory-p (concat (alchemist-project-root) "lib/" (alchemist-app-name)))))
 
 (defun alchemist-phoenix-find-dir (directory)
   (unless (alchemist-phoenix-project-p)
@@ -46,43 +47,43 @@
 
 (defun alchemist-phoenix-find-web ()
   (interactive)
-  (alchemist-phoenix-find-dir "web"))
+  (alchemist-phoenix-find-dir (concat "lib/" (alchemist-app-name) "_web")))
 
 (defun alchemist-phoenix-find-views ()
   (interactive)
-  (alchemist-phoenix-find-dir "web/views"))
+  (alchemist-phoenix-find-dir (concat "lib/" (alchemist-app-name) "_web/views")))
 
 (defun alchemist-phoenix-find-controllers ()
   (interactive)
-  (alchemist-phoenix-find-dir "web/controllers"))
+  (alchemist-phoenix-find-dir (concat "lib/" (alchemist-app-name) "_web/controllers")))
 
 (defun alchemist-phoenix-find-channels ()
   (interactive)
-  (alchemist-phoenix-find-dir "web/channels"))
+  (alchemist-phoenix-find-dir (concat "lib/" (alchemist-app-name) "_web/channels")))
 
 (defun alchemist-phoenix-find-templates ()
   (interactive)
-  (alchemist-phoenix-find-dir "web/templates"))
+  (alchemist-phoenix-find-dir (concat "lib/" (alchemist-app-name) "_web/templates")))
 
 (defun alchemist-phoenix-find-models ()
   (interactive)
-  (alchemist-phoenix-find-dir "web/models"))
+  (alchemist-phoenix-find-dir (concat "lib/" (alchemist-app-name) "_web/models")))
 
 (defun alchemist-phoenix-find-static ()
   (interactive)
-  (alchemist-phoenix-find-dir "web/static"))
+  (alchemist-phoenix-find-dir (concat "lib/" (alchemist-app-name) "_web/static")))
 
 (defun alchemist-phoenix-routes (&optional prefix)
   (interactive)
-  "Run the Mix task 'phoenix.routes' and list all available Phoenix routes."
-  (alchemist-mix-execute '("phoenix.routes") prefix))
+  "Run the Mix task 'phx.routes' and list all available Phoenix routes."
+  (alchemist-mix-execute '("phx.routes") prefix))
 
 (defun alchemist-phoenix-router ()
   "Open the 'router.ex' file from 'web' directory."
   (interactive)
   (unless (alchemist-phoenix-project-p)
     (error "Could not find an Phoenix Mix project root."))
-  (find-file (concat (alchemist-project-root) "web/router.ex")))
+  (find-file (concat (alchemist-project-root) "lib/" (alchemist-app-name) "_web/router.ex")))
 
 (defvar alchemist-phoenix-command-map
   (let ((map (make-sparse-keymap)))
@@ -143,3 +144,6 @@ The following commands are available:
 (provide 'alchemist-phoenix)
 
 ;;; alchemist-phoenix.el ends here
+
+(defun alchemist-app-name ()
+  (car (cdr (reverse (split-string (alchemist-project-root) "/")))))


### PR DESCRIPTION
The `web' directory is removed with phx1.3 and placed under
lib/<app-name>_web instead.

Also change phoenix.routes -> phx.routes