### PR TITLE
Switch default keybinding from C-c a to C-c ;

### DIFF
--- a/alchemist-key.el
+++ b/alchemist-key.el
@@ -30,7 +30,7 @@
   :prefix "alchemist-key-"
   :group 'alchemist)
 
-(defcustom alchemist-key-command-prefix (kbd "C-c a")
+(defcustom alchemist-key-command-prefix (kbd "C-c ;")
   "The prefix for Alchemist related key commands."
   :type 'string
   :group 'alchemist)

--- a/doc/alchemist-refcard.tex
+++ b/doc/alchemist-refcard.tex
@@ -58,37 +58,37 @@
 
 \group{Mix}
 
-\key{C-c a x}{alchemist-mix}
-\key{C-c a m c}{alchemist-mix-compile}
-\key{C-c a m r}{alchemist-mix-run}
+\key{C-c ; x}{alchemist-mix}
+\key{C-c ; m c}{alchemist-mix-compile}
+\key{C-c ; m r}{alchemist-mix-run}
 
 \group{Testing}
-\key{C-c a t}{alchemist-mix-test}
-\key{C-c a r}{alchemist-mix-rerun-last-test}
-\key{C-c a m t f}{alchemist-mix-test-file}
-\key{C-c a m t b}{alchemist-mix-test-this-buffer}
-\key{C-c a m t .}{alchemist-mix-test-at-point}
-\key{C-c a m t s}{alchemist-mix-test-stale}
+\key{C-c ; t}{alchemist-mix-test}
+\key{C-c ; r}{alchemist-mix-rerun-last-test}
+\key{C-c ; m t f}{alchemist-mix-test-file}
+\key{C-c ; m t b}{alchemist-mix-test-this-buffer}
+\key{C-c ; m t .}{alchemist-mix-test-at-point}
+\key{C-c ; m t s}{alchemist-mix-test-stale}
 \key{C-c M-r}{alchemist-test-toggle-test-report-display}
 
 \group{Compilation}
 
-\key{C-c a c c}{alchemist-compile}
-\key{C-c a c f}{alchemist-compile-file}
-\key{C-c a c b}{alchemist-compile-this-buffer}
+\key{C-c ; c c}{alchemist-compile}
+\key{C-c ; c f}{alchemist-compile-file}
+\key{C-c ; c b}{alchemist-compile-this-buffer}
 
 \group{Execution}
 
-\key{C-c a e e}{alchemist-execute}
-\key{C-c a e f}{alchemist-execute-file}
-\key{C-c a e b}{alchemist-execute-this-buffer}
+\key{C-c ; e e}{alchemist-execute}
+\key{C-c ; e f}{alchemist-execute-file}
+\key{C-c ; e b}{alchemist-execute-this-buffer}
 
 \group{Documentation}
 
-\key{C-c a h h}{alchemist-help}
-\key{C-c a h i}{alchemist-help-history}
-\key{C-c a h e}{alchemist-help-search-at-point}
-\key{C-c a h r}{alchemist-refcard}
+\key{C-c ; h h}{alchemist-help}
+\key{C-c ; h i}{alchemist-help-history}
+\key{C-c ; h e}{alchemist-help-search-at-point}
+\key{C-c ; h r}{alchemist-refcard}
 
 \group{Navigation}
 
@@ -100,36 +100,36 @@
 
 \group{Project}
 
-\key{C-c a p f}{alchemist-project-find-test}
-\key{C-c a p s}{alchemist-project-toggle-file-and-tests}
-\key{C-c a p o}{alchemist-project-toggle-file-and-tests-other-window}
-\key{C-c a p t}{alchemist-project-run-tests-for-current-file}
+\key{C-c ; p f}{alchemist-project-find-test}
+\key{C-c ; p s}{alchemist-project-toggle-file-and-tests}
+\key{C-c ; p o}{alchemist-project-toggle-file-and-tests-other-window}
+\key{C-c ; p t}{alchemist-project-run-tests-for-current-file}
 
 \group{IEx REPL}
 
-\key{C-c a i i}{alchemist-iex-run}
-\key{C-c a i p}{alchemist-iex-project-run}
-\key{C-c a i l}{alchemist-iex-send-current-line}
-\key{C-c a i c}{alchemist-iex-send-current-line-and-go}
-\key{C-c a i r}{alchemist-iex-send-region}
-\key{C-c a i m}{alchemist-iex-send-region-and-go}
-\key{C-c a i b}{alchemist-iex-compile-this-buffer}
+\key{C-c ; i i}{alchemist-iex-run}
+\key{C-c ; i p}{alchemist-iex-project-run}
+\key{C-c ; i l}{alchemist-iex-send-current-line}
+\key{C-c ; i c}{alchemist-iex-send-current-line-and-go}
+\key{C-c ; i r}{alchemist-iex-send-region}
+\key{C-c ; i m}{alchemist-iex-send-region-and-go}
+\key{C-c ; i b}{alchemist-iex-compile-this-buffer}
 
 \group{Evaluation}
 
-\key{C-c a v l}{alchemist-eval-current-line}
-\key{C-c a v k}{alchemist-eval-print-current-line}
-\key{C-c a v j}{alchemist-eval-quoted-current-line}
-\key{C-c a v h}{alchemist-eval-print-quoted-current-line}
-\key{C-c a v o}{alchemist-eval-region}
-\key{C-c a v i}{alchemist-eval-print-region}
-\key{C-c a v u}{alchemist-eval-quoted-region}
-\key{C-c a v y}{alchemist-eval-print-quoted-region}
-\key{C-c a v q}{alchemist-eval-buffer}
-\key{C-c a v w}{alchemist-eval-print-buffer}
-\key{C-c a v e}{alchemist-eval-quoted-buffer}
-\key{C-c a v r}{alchemist-eval-print-quoted-buffer}
-\key{C-c a v !}{alchemist-eval-close-popup}
+\key{C-c ; v l}{alchemist-eval-current-line}
+\key{C-c ; v k}{alchemist-eval-print-current-line}
+\key{C-c ; v j}{alchemist-eval-quoted-current-line}
+\key{C-c ; v h}{alchemist-eval-print-quoted-current-line}
+\key{C-c ; v o}{alchemist-eval-region}
+\key{C-c ; v i}{alchemist-eval-print-region}
+\key{C-c ; v u}{alchemist-eval-quoted-region}
+\key{C-c ; v y}{alchemist-eval-print-quoted-region}
+\key{C-c ; v q}{alchemist-eval-buffer}
+\key{C-c ; v w}{alchemist-eval-print-buffer}
+\key{C-c ; v e}{alchemist-eval-quoted-buffer}
+\key{C-c ; v r}{alchemist-eval-print-quoted-buffer}
+\key{C-c ; v !}{alchemist-eval-close-popup}
 
 \end{multicols}
 

--- a/doc/basic_usage.md
+++ b/doc/basic_usage.md
@@ -2,10 +2,10 @@
 
 | Keybinding | Description |
 |-------------------|-------------|
-|<kbd>C-c a x</kbd>|Prompt for a mix command including a list of all available mix commands. `alchemist-mix`|
-|<kbd>C-c a m c</kbd>|Compile the whole elixir project. `alchemist-mix-compile`|
-|<kbd>C-c a m r</kbd>|Runs the given file or expression in the context of the application. `alchemist-mix-run`|
-|<kbd>C-c a m l</kbd>|Rerun the last mix task which was run by alchemist. `alchemist-mix-rerun-last-task`|
+|<kbd>C-c ; x</kbd> |Prompt for a mix command including a list of all available mix commands. `alchemist-mix`|
+|<kbd>C-c ; m c</kbd> |Compile the whole elixir project. `alchemist-mix-compile`|
+|<kbd>C-c ; m r</kbd> |Runs the given file or expression in the context of the application. `alchemist-mix-run`|
+|<kbd>C-c ; m l</kbd> |Rerun the last mix task which was run by alchemist. `alchemist-mix-rerun-last-task`|
 
 Mix tasks could also be executed in a specific environment with the usage of `C-u` (universal-argument).
 Default environments are `prod`, `dev` and `test`. [Mix environments](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html#environments)
@@ -24,25 +24,25 @@ The Mix tasks running in a separate `alchemist-mix-mode`, in which the following
 
 | Keybinding   | Description                                          |
 |--------------|------------------------------------------------------|
-|<kbd>C-c a X i</kbd>  | Display Hex package information for the package at point. |
-|<kbd>C-c a X r</kbd>  | Display Hex package releases for the package at point. |
-|<kbd>C-c a X I</kbd>  | Display Hex package info for a certain package. |
-|<kbd>C-c a X R</kbd>  | Display Hex package releases for a certain package.|
-|<kbd>C-c a X s</kbd>  | Search for Hex packages. |
-|<kbd>C-c a X d</kbd>  | Display Hex package dependencies for the current Mix project. |
+|<kbd>C-c ; X i</kbd>  | Display Hex package information for the package at point. |
+|<kbd>C-c ; X r</kbd>  | Display Hex package releases for the package at point. |
+|<kbd>C-c ; X I</kbd>  | Display Hex package info for a certain package. |
+|<kbd>C-c ; X R</kbd>  | Display Hex package releases for a certain package.|
+|<kbd>C-c ; X s</kbd>  | Search for Hex packages. |
+|<kbd>C-c ; X d</kbd>  | Display Hex package dependencies for the current Mix project. |
 
 
 ## Testing
 
 | Keybinding | Description |
 |-------------------|-------------|
-|<kbd>C-c a t</kbd>|Run the whole elixir test suite. `alchemist-mix-test`|
-|<kbd>C-c a r</kbd>|Rerun the last test that was run by alchemist. `alchemist-mix-rerun-last-test`|
-|<kbd>C-c a m t f</kbd>|Run `alchemist-mix--test-file` with the FILENAME. `alchemist-mix-test-file`|
-|<kbd>C-c a m t b</kbd>|Run the current buffer through mix test. `alchemist-mix-test-this-buffer`|
-|<kbd>C-c a m t .</kbd>|Run the test at point. `alchemist-mix-test-at-point`|
-|<kbd>C-c a m t s</kbd>|Run only stale tests (Elixir 1.3+). `alchemist-mix-test-stale` |
-|<kbd>C-c a m t r</kbd>|Rerun the last test that was run by alchemist. `alchemist-mix-rerun-last-test` |
+|<kbd>C-c ; t</kbd>|Run the whole elixir test suite. `alchemist-mix-test`|
+|<kbd>C-c ; r</kbd>|Rerun the last test that was run by alchemist. `alchemist-mix-rerun-last-test`|
+|<kbd>C-c ; m t f</kbd>|Run `alchemist-mix--test-file` with the FILENAME. `alchemist-mix-test-file`|
+|<kbd>C-c ; m t b</kbd>|Run the current buffer through mix test. `alchemist-mix-test-this-buffer`|
+|<kbd>C-c ; m t .</kbd>|Run the test at point. `alchemist-mix-test-at-point`|
+|<kbd>C-c ; m t s</kbd>|Run only stale tests (Elixir 1.3+). `alchemist-mix-test-stale` |
+|<kbd>C-c ; m t r</kbd>|Rerun the last test that was run by alchemist. `alchemist-mix-rerun-last-test` |
 |<kbd>C-c M-r</kbd>|Toggle between displaying or hidding the test report buffer. `alchemist-test-toggle-test-report-display`|
 
 ## Compile And Execute
@@ -51,41 +51,41 @@ The Mix tasks running in a separate `alchemist-mix-mode`, in which the following
 
 | Keybinding | Description |
 |-------------------|-------------|
-|<kbd>C-c a c b</kbd>|Compile the current buffer with the `elixirc` command. `alchemist-compile-this-buffer`|
-|<kbd>C-c a c f</kbd>|Compile the given `FILENAME` with the `elixirc` command. `alchemist-compile-file`|
-|<kbd>C-c a c c</kbd>|Run a custom compile command with `elixirc`. `alchemist-compile`|
+|<kbd>C-c ; c b</kbd>|Compile the current buffer with the `elixirc` command. `alchemist-compile-this-buffer`|
+|<kbd>C-c ; c f</kbd>|Compile the given `FILENAME` with the `elixirc` command. `alchemist-compile-file`|
+|<kbd>C-c ; c c</kbd>|Run a custom compile command with `elixirc`. `alchemist-compile`|
 
 ### Execute functions
 
 | Keybinding | Description |
 |-------------------|-------------|
-|<kbd>C-c a e b</kbd>|Run the current buffer through `elixir` command. `alchemist-execute-this-buffer`|
-|<kbd>C-c a e f</kbd>|Run `elixir` command with the given `FILENAME`. `alchemist-execute-file` |
-|<kbd>C-c a e e</kbd>|Run a custom execute command with `elixir`. `alchemist-execute` |
+|<kbd>C-c ; e b</kbd>|Run the current buffer through `elixir` command. `alchemist-execute-this-buffer`|
+|<kbd>C-c ; e f</kbd>|Run `elixir` command with the given `FILENAME`. `alchemist-execute-file` |
+|<kbd>C-c ; e e</kbd>|Run a custom execute command with `elixir`. `alchemist-execute` |
 
 ## Project
 
 | Keybinding | Description |
 |-------------------|-------------|
-|<kbd>C-c a p s</kbd>|Toggle between a file and its tests in the current window. `alchemist-project-toggle-file-and-tests`|
-|<kbd>C-c a p o</kbd>|Toggle between a file and its tests in other window. `alchemist-project-toggle-file-and-tests-other-window`|
-|<kbd>C-c a p t</kbd>|Run the tests related to the current file. `alchemist-project-run-tests-for-current-file`|
-|<kbd>C-c a p f</kbd>|List all files available in the `test` directory. `alchemist-project-find-test`|
-|<kbd>C-c a p l</kbd>|List all files available in the `lib` directory. `alchemist-project-find-lib` |
+|<kbd>C-c ; p s</kbd>|Toggle between a file and its tests in the current window. `alchemist-project-toggle-file-and-tests`|
+|<kbd>C-c ; p o</kbd>|Toggle between a file and its tests in other window. `alchemist-project-toggle-file-and-tests-other-window`|
+|<kbd>C-c ; p t</kbd>|Run the tests related to the current file. `alchemist-project-run-tests-for-current-file`|
+|<kbd>C-c ; p f</kbd>|List all files available in the `test` directory. `alchemist-project-find-test`|
+|<kbd>C-c ; p l</kbd>|List all files available in the `lib` directory. `alchemist-project-find-lib` |
 
 ## alchemist-phoenix-mode
 
 | Keybinding | Description |
 |-------------------|-------------|
-|<kbd>C-c a n w</kbd>|List all files available in the `web` directory. `alchemist-phoenix-find-web`|
-|<kbd>C-c a n c</kbd>|List all controllers in `web/controllers` directory. `alchemist-phoenix-find-controllers`|
-|<kbd>C-c a n l</kbd>|List all channels in `web/channels` directory. `alchemist-phoenix-find-channels`|
-|<kbd>C-c a n t</kbd>|List all templates in `web/templates` directory. `alchemist-phoenix-find-templates`|
-|<kbd>C-c a n m</kbd>|List all models in `web/models` directory. `alchemist-phoenix-find-models`|
-|<kbd>C-c a n v</kbd>|List all views in `web/views` directory. `alchemist-phoenix-find-views`|
-|<kbd>C-c a n s</kbd>|List all files in `web/static` directory. `alchemist-phoenix-find-static`|
-|<kbd>C-c a n r</kbd>|Open the `router.ex` file in `web` directory. `alchemist-phoenix-router`|
-|<kbd>C-c a n R</kbd>|Run the Mix task `phoenix.routes`. `alchemist-phoenix-routes`|
+|<kbd>C-c ; n w</kbd>|List all files available in the `web` directory. `alchemist-phoenix-find-web`|
+|<kbd>C-c ; n c</kbd>|List all controllers in `web/controllers` directory. `alchemist-phoenix-find-controllers`|
+|<kbd>C-c ; n l</kbd>|List all channels in `web/channels` directory. `alchemist-phoenix-find-channels`|
+|<kbd>C-c ; n t</kbd>|List all templates in `web/templates` directory. `alchemist-phoenix-find-templates`|
+|<kbd>C-c ; n m</kbd>|List all models in `web/models` directory. `alchemist-phoenix-find-models`|
+|<kbd>C-c ; n v</kbd>|List all views in `web/views` directory. `alchemist-phoenix-find-views`|
+|<kbd>C-c ; n s</kbd>|List all files in `web/static` directory. `alchemist-phoenix-find-static`|
+|<kbd>C-c ; n r</kbd>|Open the `router.ex` file in `web` directory. `alchemist-phoenix-router`|
+|<kbd>C-c ; n R</kbd>|Run the Mix task `phoenix.routes`. `alchemist-phoenix-routes`|
 
 ## Documentation lookup
 
@@ -99,10 +99,10 @@ installed on the system, the documentation you get by `alchemist` is the same
 
 | Keybinding | Description                                     |
 |------------|-------------------------------------------------|
-|<kbd>C-c a h h</kbd>| Run a custom search. `alchemist-help`              |
-|<kbd>C-c a h i</kbd>| Look through search history. `alchemist-help-history` |
-|<kbd>C-c a h e</kbd>| Run `alchemist-help` with the expression under the cursor. (example: `is_binary`  or `Code.eval_string`). If there is a currently marked region this will be used as the search term. `alchemist-help-search-at-point` |
-|<kbd>C-c a h r</kbd>| Open a buffer with a refcard of alchemist bindings. `alchemist-refcard`|
+|<kbd>C-c ; h h</kbd>| Run a custom search. `alchemist-help`              |
+|<kbd>C-c ; h i</kbd>| Look through search history. `alchemist-help-history` |
+|<kbd>C-c ; h e</kbd>| Run `alchemist-help` with the expression under the cursor. (example: `is_binary`  or `Code.eval_string`). If there is a currently marked region this will be used as the search term. `alchemist-help-search-at-point` |
+|<kbd>C-c ; h r</kbd>| Open a buffer with a refcard of alchemist bindings. `alchemist-refcard`|
 
 ### Alchemist Help Minor Mode Keymap
 
@@ -202,14 +202,14 @@ before run <kbd>M-x alchemist-iex-run</kbd>
 
 | Keybinding | Description |
 |--------------------|------------------------------------------|
-|<kbd>C-c a i i</kbd>| Start an IEx process. `alchemist-iex-run`|
-|<kbd>C-c a i p</kbd>| Start an IEx process with mix (`iex -S mix`). `alchemist-iex-project-run`|
-|<kbd>C-c a i l</kbd>| Sends the current line to the IEx process. `alchemist-iex-send-current-line`|
-|<kbd>C-c a i c</kbd>| Sends the current line to the IEx process and jump to the buffer. `alchemist-iex-send-current-line-and-go`|
-|<kbd>C-c a i r</kbd>| Sends the marked region to the IEx process. `alchemist-iex-send-region`|
-|<kbd>C-c a i m</kbd>| Sends the marked region to the IEx process and jump to the buffer. `alchemist-iex-send-region-and-go`|
-|<kbd>C-c a i b</kbd>| Compiles the current buffer in the IEx process. `alchemist-iex-compile-this-buffer`|
-|<kbd>C-c a i R</kbd>| Recompiles and reloads the current module in the IEx process. `alchemist-iex-reload-module`|
+|<kbd>C-c ; i i</kbd>| Start an IEx process. `alchemist-iex-run`|
+|<kbd>C-c ; i p</kbd>| Start an IEx process with mix (`iex -S mix`). `alchemist-iex-project-run`|
+|<kbd>C-c ; i l</kbd>| Sends the current line to the IEx process. `alchemist-iex-send-current-line`|
+|<kbd>C-c ; i c</kbd>| Sends the current line to the IEx process and jump to the buffer. `alchemist-iex-send-current-line-and-go`|
+|<kbd>C-c ; i r</kbd>| Sends the marked region to the IEx process. `alchemist-iex-send-region`|
+|<kbd>C-c ; i m</kbd>| Sends the marked region to the IEx process and jump to the buffer. `alchemist-iex-send-region-and-go`|
+|<kbd>C-c ; i b</kbd>| Compiles the current buffer in the IEx process. `alchemist-iex-compile-this-buffer`|
+|<kbd>C-c ; i R</kbd>| Recompiles and reloads the current module in the IEx process. `alchemist-iex-reload-module`|
 
 ### Complete & Documentation lookup
 
@@ -222,33 +222,33 @@ Alchemist comes with the functionality to evaluate code inside the buffer.
 
 | Keybinding | Description |
 |--------------------|------------------------------------------|
-|<kbd>C-c a v l</kbd>| Evaluate the Elixir code on the current line. `alchemist-eval-current-line`.|
-|<kbd>C-c a v k</kbd>| Evaluate the Elixir code on the current line and insert the result. `alchemist-eval-print-current-line`.|
-|<kbd>C-c a v j</kbd>| Get the Elixir code representation of the expression on the current line. `alchemist-eval-quoted-current-line`. |
-|<kbd>C-c a v h</kbd>| Get the Elixir code representation of the expression on the current line and insert the result. `alchemist-eval-print-quoted-current-line`. |
-|<kbd>C-c a v o</kbd>| Evaluate the Elixir code on marked region. `alchemist-eval-region`.|
-|<kbd>C-c a v i</kbd>| Evaluate the Elixir code on marked region and insert the result. `alchemist-eval-print-region`.|
-|<kbd>C-c a v u</kbd>| Get the Elixir code representation of the expression on marked region. `alchemist-eval-quoted-region`.|
-|<kbd>C-c a v y</kbd>| Get the Elixir code representation of the expression on marked region and insert the result. `alchemist-eval-print-quoted-region`.|
-|<kbd>C-c a v q</kbd>| Evaluate the Elixir code in the current buffer. `alchemist-eval-buffer`.|
-|<kbd>C-c a v w</kbd>| Evaluate the Elixir code in the current buffer and insert the result. `alchemist-eval-print-buffer`.|
-|<kbd>C-c a v e</kbd>| Get the Elixir code representation of the expression in the current buffer. `alchemist-eval-quoted-buffer`.|
-|<kbd>C-c a v r</kbd>| Get the Elixir code representation of the expression in the current buffer and insert result. `alchemist-eval-print-quoted-buffer`.|
-|<kbd>C-c a v !</kbd>| Quit the Elixir evaluation popup window. `alchemist-eval-close-popup`.|
+|<kbd>C-c ; v l</kbd>| Evaluate the Elixir code on the current line. `alchemist-eval-current-line`.|
+|<kbd>C-c ; v k</kbd>| Evaluate the Elixir code on the current line and insert the result. `alchemist-eval-print-current-line`.|
+|<kbd>C-c ; v j</kbd>| Get the Elixir code representation of the expression on the current line. `alchemist-eval-quoted-current-line`. |
+|<kbd>C-c ; v h</kbd>| Get the Elixir code representation of the expression on the current line and insert the result. `alchemist-eval-print-quoted-current-line`. |
+|<kbd>C-c ; v o</kbd>| Evaluate the Elixir code on marked region. `alchemist-eval-region`.|
+|<kbd>C-c ; v i</kbd>| Evaluate the Elixir code on marked region and insert the result. `alchemist-eval-print-region`.|
+|<kbd>C-c ; v u</kbd>| Get the Elixir code representation of the expression on marked region. `alchemist-eval-quoted-region`.|
+|<kbd>C-c ; v y</kbd>| Get the Elixir code representation of the expression on marked region and insert the result. `alchemist-eval-print-quoted-region`.|
+|<kbd>C-c ; v q</kbd>| Evaluate the Elixir code in the current buffer. `alchemist-eval-buffer`.|
+|<kbd>C-c ; v w</kbd>| Evaluate the Elixir code in the current buffer and insert the result. `alchemist-eval-print-buffer`.|
+|<kbd>C-c ; v e</kbd>| Get the Elixir code representation of the expression in the current buffer. `alchemist-eval-quoted-buffer`.|
+|<kbd>C-c ; v r</kbd>| Get the Elixir code representation of the expression in the current buffer and insert result. `alchemist-eval-print-quoted-buffer`.|
+|<kbd>C-c ; v !</kbd>| Quit the Elixir evaluation popup window. `alchemist-eval-close-popup`.|
 
 ## Macroexpand
 
 | Keybinding | Description | Command |
 |--------------------|------------------------------------------|------------------------------------------------|
-|<kbd>C-c a o l</kbd>| Macro expand once on the current line. | `alchemist-macroexpand-once-current-line`.|
-|<kbd>C-c a o L</kbd>| Macro expand once on the current line and print the result. | `alchemist-macroexpand-once-print-current-line`.|
-|<kbd>C-c a o k</kbd>| Macro expand on the current line. | `alchemist-macroexpand-current-line`.|
-|<kbd>C-c a o K</kbd>| Macro expand on the current line and print the result. | `alchemist-macroexpand-print-current-line`.|
-|<kbd>C-c a o i</kbd>| Macro expand once on region. | `alchemist-macroexpand-once-region`.|
-|<kbd>C-c a o I</kbd>| Macro expand once on region and print the result. | `alchemist-macroexpand-once-print-region`.|
-|<kbd>C-c a o r</kbd>| Macro expand on region. | `alchemist-macroexpand-region`.|
-|<kbd>C-c a o R</kbd>| Macro expand on region and print the result. | `alchemist-macroexpand-print-region`.|
-|<kbd>C-c a o !</kbd>| Quit the Elixir macroexpand popup window. | `alchemist-macroexpand-close-popup`.|
+|<kbd>C-c ; o l</kbd>| Macro expand once on the current line. | `alchemist-macroexpand-once-current-line`.|
+|<kbd>C-c ; o L</kbd>| Macro expand once on the current line and print the result. | `alchemist-macroexpand-once-print-current-line`.|
+|<kbd>C-c ; o k</kbd>| Macro expand on the current line. | `alchemist-macroexpand-current-line`.|
+|<kbd>C-c ; o K</kbd>| Macro expand on the current line and print the result. | `alchemist-macroexpand-print-current-line`.|
+|<kbd>C-c ; o i</kbd>| Macro expand once on region. | `alchemist-macroexpand-once-region`.|
+|<kbd>C-c ; o I</kbd>| Macro expand once on region and print the result. | `alchemist-macroexpand-once-print-region`.|
+|<kbd>C-c ; o r</kbd>| Macro expand on region. | `alchemist-macroexpand-region`.|
+|<kbd>C-c ; o R</kbd>| Macro expand on region and print the result. | `alchemist-macroexpand-print-region`.|
+|<kbd>C-c ; o !</kbd>| Quit the Elixir macroexpand popup window. | `alchemist-macroexpand-close-popup`.|
 
 **Note**
 
@@ -284,8 +284,8 @@ These two helper functions are available now with the following keybindings/func
 
 | Keybinding | Description |
 |--------------------|------------------------------------------|
-|<kbd>C-c a f i</kbd>| Prints information about any datatype under the cursor. `alchemist-info-datatype-at-point` |
-|<kbd>C-c a f t</kbd>| Prints information of types under the cursor. `alchemist-info-types-at-point` |
+|<kbd>C-c ; f i</kbd>| Prints information about any datatype under the cursor. `alchemist-info-datatype-at-point` |
+|<kbd>C-c ; f t</kbd>| Prints information of types under the cursor. `alchemist-info-types-at-point` |
 
 ## Testing Mode
 
@@ -319,7 +319,7 @@ The tests are reported in the `alchemist-test-report-mode`, which have the follo
 
 Alchemist comes with a default keymap.
 
-The the default prefix keybinding is <kbd>C-c a</kbd>
+The default prefix keybinding is <kbd>C-c ;</kbd>. It can configured to something else easily, see the documentation.
 
 ### Refcards
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -66,10 +66,10 @@ through the variable.
 
 ### Keybindings
 
-* Use a different keybinding prefix than <kbd>C-c a</kbd>
+* Use a different keybinding prefix than <kbd>C-c ;</kbd>
 
 ```el
-(setq alchemist-key-command-prefix (kbd "C-c ,")) ;; default: (kbd "C-c a")
+(setq alchemist-key-command-prefix (kbd "C-c ,")) ;; default: (kbd "C-c ;")
 ```
 
 ### Testing Mode


### PR DESCRIPTION
This is a simple, mostly configuration-based PR that addresses #229 and brings alchemist into the rank of the packages that respect emacs conventions.

There's probably more things I need to do here, like regenerate the PDF and such, but I'm not sure how to do it.

I also know that just merging in this PR is no easy feat, but if we don't open it, we'll _NEVER_ merge it :)