### PR TITLE
Jump to module from function documentation

### DIFF
--- a/alchemist-help.el
+++ b/alchemist-help.el
@@ -230,6 +230,10 @@ the actively marked region will be used for passing to `alchemist-help'."
       (alchemist-help--search-at-point)))
 
 (defun alchemist-help-module ()
+  "Load Elixir documentation for the module of the most recent SEARCH.
+
+This is helpful to jump from the documentation of, say, the String.split/1
+function to the documetation of the String module."
   (interactive)
   (let* ((current-search (car alchemist-help-search-history))
          (module (alchemist-scope-extract-module current-search))

--- a/alchemist-help.el
+++ b/alchemist-help.el
@@ -144,7 +144,7 @@ Argument END where the mark ends."
            "]-search-at-point ["
            (propertize "m" 'face 'alchemist-help-key-face)
            "]-search-module ["
-           (propertize "m" 'face 'alchemist-help-key-face)
+           (propertize "s" 'face 'alchemist-help-key-face)
            "]-search ["
            (propertize "h" 'face 'alchemist-help-key-face)
            "]-history ["

--- a/alchemist-help.el
+++ b/alchemist-help.el
@@ -229,10 +229,17 @@ the actively marked region will be used for passing to `alchemist-help'."
       (alchemist-help--search-marked-region (region-beginning) (region-end))
       (alchemist-help--search-at-point)))
 
+(defun alchemist-help-module ()
+  (interactive)
+  (let* ((current-search (car alchemist-help-search-history))
+         (module-name (car (split-string current-search "\\."))))
+    (alchemist-help-lookup-doc (alchemist-help--prepare-search-expr module-name))))
+
 (defvar alchemist-help-minor-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") #'quit-window)
     (define-key map (kbd "e") #'alchemist-help-search-at-point)
+    (define-key map (kbd "m") #'alchemist-help-module)
     (define-key map (kbd "s") #'alchemist-help)
     (define-key map (kbd "h") #'alchemist-help-history)
     (define-key map (kbd "M-.") #'alchemist-goto-definition-at-point)

--- a/alchemist-help.el
+++ b/alchemist-help.el
@@ -142,7 +142,9 @@ Argument END where the mark ends."
            "]-quit ["
            (propertize "e" 'face 'alchemist-help-key-face)
            "]-search-at-point ["
-           (propertize "s" 'face 'alchemist-help-key-face)
+           (propertize "m" 'face 'alchemist-help-key-face)
+           "]-search-module ["
+           (propertize "m" 'face 'alchemist-help-key-face)
            "]-search ["
            (propertize "h" 'face 'alchemist-help-key-face)
            "]-history ["

--- a/alchemist-help.el
+++ b/alchemist-help.el
@@ -232,8 +232,12 @@ the actively marked region will be used for passing to `alchemist-help'."
 (defun alchemist-help-module ()
   (interactive)
   (let* ((current-search (car alchemist-help-search-history))
-         (module-name (car (split-string current-search "\\."))))
-    (alchemist-help-lookup-doc (alchemist-help--prepare-search-expr module-name))))
+         (module (alchemist-scope-extract-module current-search))
+         (module (alchemist-scope-alias-full-path module)))
+
+    (if module
+        (alchemist-help-lookup-doc (alchemist-help--prepare-search-expr module))
+      (message "No module found"))))
 
 (defvar alchemist-help-minor-mode-map
   (let ((map (make-sparse-keymap)))

--- a/doc/basic_usage.md
+++ b/doc/basic_usage.md
@@ -114,13 +114,14 @@ You're always be able to continue to search inside the `*elixir help*` buffer.
 Hit <kbd>?</kbd> to get the keybinding summary for the `alchemist-help-minor-mode`.
 
 ```
-[q]-quit [e]-search-at-point [s]-search [h]-history [?]-keys
+[q]-quit [e]-search-at-point [m]-search-module [s]-search [h]-history [?]-keys
 ```
 
 | Keybinding | Description                                     |
 |------------|-------------------------------------------------|
 |<kbd>q</kbd>| Quit `*elixir help*` buffer window              |
 |<kbd>e</kbd>| `alchemist-help-search-at-point`                |
+|<kbd>m</kdb>| `alchemist-help-module`                         |
 |<kbd>s</kbd>| `alchemist-help`                                |
 |<kbd>h</kbd>| `alchemist-help-history`                        |
 |<kbd>?</kbd>| `alchemist-help-minor-mode-key-binding-summary` |


### PR DESCRIPTION
When viewing the documentation for a function, this PR modifies the `alchemist-help-minor-mode-map` to allow you to jump to documentation for that function's module by hitting the `m` key.  E.g. if you're reading about `String.split/1`, you can jump to the documentation for `String` in a single keystroke.