### PR TITLE
Run tests with Emacs' compile function

### DIFF
--- a/alchemist-report.el
+++ b/alchemist-report.el
@@ -97,9 +97,6 @@ Argument for the exit function is the STATUS and BUFFER of the finished process.
   "Process filter for report buffers."
   (with-current-buffer (process-buffer process)
     (let* ((buffer-read-only nil)
-           (output (if (string= (process-name process) alchemist-test-report-process-name)
-                       (alchemist-test-clean-compilation-output output)
-                     output))
            (moving (= (point) (process-mark process))))
       (save-excursion
         (goto-char (process-mark process))

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -171,15 +171,6 @@ macro) while the values are the position at which the test matched."
   "Save some modified file-visiting buffers."
   (save-some-buffers (not alchemist-test-ask-about-save) nil))
 
-(defun alchemist-test-clean-compilation-output (output)
-  (if (not alchemist-test-display-compilation-output)
-      (with-temp-buffer
-        (insert output)
-        (delete-matching-lines "^Compiled .+" (point-min) (point-max))
-        (delete-matching-lines "^Generated .+" (point-min) (point-max))
-        (buffer-substring-no-properties (point-min) (point-max)))
-  output))
-
 (defun alchemist-test-execute (command-list)
   (message "Testing...")
   (let* ((default-directory (or (alchemist-project-root) default-directory))
@@ -189,7 +180,18 @@ macro) while the values are the position at which the test matched."
 
 (define-compilation-mode alchemist-test-compilation-mode "Alchemist Test Compilation"
   "Compilation mode for mix test output from Alchemist"
-  (add-hook 'compilation-filter-hook 'alchemist-test-colorize-compilation-buffer nil t))
+  (add-hook 'compilation-filter-hook 'alchemist-test-colorize-compilation-buffer nil t)
+  (add-hook 'compilation-finish-functions 'alchemist-test-clean-compilation-output))
+
+(defun alchemist-test-clean-compilation-output (buffer mesage)
+  (unless alchemist-test-display-compilation-output
+    (toggle-read-only)
+    (save-excursion
+      (delete-matching-lines "^Compiled .+" (point-min) (point-max))
+      (delete-matching-lines "^Generated .+" (point-min) (point-max))
+      (delete-matching-lines "^Compiling .+" (point-min) (point-max))
+      (buffer-substring-no-properties (point-min) (point-max)))
+    (toggle-read-only)))
 
 (defun alchemist-test-colorize-compilation-buffer ()
   (toggle-read-only)

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -260,7 +260,16 @@ macro) while the values are the position at which the test matched."
   (message "Testing...")
   (let* ((command (mapconcat 'concat (-flatten command-list) " ")))
     (alchemist-test-save-buffers)
-    (compile command)))
+    (compile command 'alchemist-test-compilation-mode)))
+
+(define-compilation-mode alchemist-test-compilation-mode "Alchemist Test Compilation"
+  "Compilation mode for mix test output from Alchemist"
+  (add-hook 'compilation-filter-hook 'alchemist-test-colorize-compilation-buffer nil t))
+
+(defun alchemist-test-colorize-compilation-buffer ()
+  (toggle-read-only)
+  (ansi-color-apply-on-region compilation-filter-start (point))
+  (toggle-read-only))
 
 (defun alchemist-test-initialize-modeline ()
   "Initialize the mode-line face."

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -258,7 +258,8 @@ macro) while the values are the position at which the test matched."
 
 (defun alchemist-test-execute (command-list)
   (message "Testing...")
-  (let* ((command (mapconcat 'concat (-flatten command-list) " ")))
+  (let* ((default-directory (or (alchemist-project-root) default-directory))
+         (command (mapconcat 'concat (-flatten command-list) " ")))
     (alchemist-test-save-buffers)
     (compile command 'alchemist-test-compilation-mode)))
 

--- a/alchemist-test-mode.el
+++ b/alchemist-test-mode.el
@@ -27,6 +27,7 @@
 
 (require 'dash)
 (require 'alchemist-project)
+(require 'compile)
 
 (defgroup alchemist-test-mode nil
   "Minor mode for Elixir ExUnit files."
@@ -259,11 +260,7 @@ macro) while the values are the position at which the test matched."
   (message "Testing...")
   (let* ((command (mapconcat 'concat (-flatten command-list) " ")))
     (alchemist-test-save-buffers)
-    (alchemist-report-run command
-                          alchemist-test-report-process-name
-                          alchemist-test-report-buffer-name
-                          'alchemist-test-report-mode
-                          #'alchemist-test--handle-exit)))
+    (compile command)))
 
 (defun alchemist-test-initialize-modeline ()
   "Initialize the mode-line face."

--- a/doc/basic_usage.md
+++ b/doc/basic_usage.md
@@ -302,18 +302,18 @@ Alchemist comes with an minor mode for testing which will be enabled by default 
 
 ### Testing Report
 
-The tests are reported in the `alchemist-test-report-mode`, which have the following keybindings:
+The tests are reported in a [compilation buffer](https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html#Compilation-Mode).  Some of the standard keybindings for that mode are:
 
-| Keybinding | Description |
-|--------------------|------------------------------------------|
-|<kbd>r</kbd>| Rerun the latest test run. `alchemist-mix-rerun-last-test` |
-|<kbd>t</kbd>| Toggle truncating of long lines for the current test buffer. `toggle-truncate-lines` |
-|<kbd>M-n</kbd>| Jump to the next error in the test report. `alchemist-test-next-result` |
-|<kbd>M-p</kbd>| Jump to the previous error in the test report. `alchemist-test-previous-result` |
-|<kbd>M-N</kbd>| Jump to the next stacktrace file in the test report. `alchemist-test-next-stacktrace-file` |
-|<kbd>M-P</kbd>| Jump to the previous stacktrace file in the test report. `alchemist-test-previous-stacktrace-file` |
-|<kbd>C-c C-k</kbd>| Interrupt the current running report process. `alchemist-report-interrupt-current-process` |
-|<kbd>q</kbd>| Close the test report window |
+| Keybinding       | Description |
+|------------------|------------------------------------------|
+|<kbd>g</kbd>      | Rerun the latest test run. Equivalent to `alchemist-mix-rerun-last-test` |
+|<kbd>M-n</kbd>    | Jump to the next error in the test report.|
+|<kbd>M-g n</kbd   | Visit the locus of the next error in another buffer.|
+|<kbd>M-p</kbd>    | Jump to the previous error in the test report. |
+|<kbd>M-g n</kbd   | Visit the locus of the previous error in another buffer.|
+|<kbd>C-c C-f</kbd>| Toggle Next Error Follow minor mode, which makes `M-{n|p}` behave like `M-g {n|p}`|
+|<kbd>C-c C-k</kbd>| Interrupt the current running report process. |
+|<kbd>q</kbd>      | Close the test report window |
 
 ## Keymap
 


### PR DESCRIPTION
By using Emacs' native `compile` function, we can take advantage of the built-in features of compilation mode for free.  That lets us do things like move between failures, open the relevant file and line from the stacktrace automatically and re-run the tests with a single keystroke.  I was surprised at how little was required to get it all hooked up, honestly.

There's a little more work to be done: I haven't tried to integrate the "test after save" hook, and the face used by the stacktrace right now is ugly.  But, this change does what I need it to and I wanted to see if there was any interest in merging something like this before I devoted time to features I don't personally use.  I'm happy to keep running a forked version if you want to keep the current implementation of test reports.

This change was inspired by [rspec-mode](https://github.com/pezra/rspec-mode)