### PR TITLE
Mix format integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: elixir
 elixir:
-  - 1.4.2
+  - 1.6.0
 otp_release:
   - 19.0
 cache: apt

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -51,6 +51,11 @@
   :type 'string
   :group 'alchemist-mix)
 
+(defcustom alchemist-mix-format-task "format"
+  "Default task to run formatting."
+  :type 'string
+  :group 'alchemist-mix)
+
 (defcustom alchemist-mix-test-default-options '()
   "Default options for alchemist test command."
   :type '(repeat string)
@@ -118,6 +123,19 @@ executed, gets called."
   (interactive)
   (when (get-buffer alchemist-mix-buffer-name)
     (display-buffer alchemist-mix-buffer-name)))
+
+(defun alchemist-mix-format ()
+  "Run format on current project's .formatter.exs"
+  (interactive)
+  (alchemist-test-execute (list alchemist-mix-command
+                                alchemist-mix-format-task)))
+
+(defun alchemist-mix-format-buffer ()
+  "Run format on the current buffer"
+  (interactive)
+  (alchemist-test-execute (list alchemist-mix-command
+                                alchemist-mix-format-task
+                                buffer-file-name)))
 
 (defun alchemist-mix-test ()
   "Run the whole elixir test suite."

--- a/alchemist-mix.el
+++ b/alchemist-mix.el
@@ -125,13 +125,13 @@ executed, gets called."
     (display-buffer alchemist-mix-buffer-name)))
 
 (defun alchemist-mix-format ()
-  "Run format on current project's .formatter.exs"
+  "Run format on current project's .formatter.exs (Elixir 1.6 and above only)"
   (interactive)
   (alchemist-test-execute (list alchemist-mix-command
                                 alchemist-mix-format-task)))
 
 (defun alchemist-mix-format-buffer ()
-  "Run format on the current buffer"
+  "Run format on the current buffer (Elixir 1.6 and above only)"
   (interactive)
   (alchemist-test-execute (list alchemist-mix-command
                                 alchemist-mix-format-task


### PR DESCRIPTION
This connects alchemist mix tasks with mix format.

Mix Format was made available in Elixir 1.6 which helps people stick with single conventions. Having these with emacs alchemist would be a great help to emacs users working with Elixir. May be the way to solve #337 