### PR TITLE
Update Phoenix project detection

### DIFF
--- a/alchemist-phoenix.el
+++ b/alchemist-phoenix.el
@@ -37,7 +37,10 @@
 (defun alchemist-phoenix-project-p ()
   "Return non-nil if `default-directory' is inside a Phoenix project."
   (and (alchemist-project-p)
-       (file-directory-p (concat (alchemist-project-root) "web"))))
+       (file-exists-p (concat (alchemist-project-root) alchemist-project-mix-project-indicator))
+       (with-temp-buffer
+	 (insert-file-contents (concat (alchemist-project-root) alchemist-project-mix-project-indicator))
+	 (string-match-p ":phoenix" (buffer-string)))))
 
 (defun alchemist-phoenix-find-dir (directory)
   (unless (alchemist-phoenix-project-p)

--- a/test/alchemist-phoenix-test.el
+++ b/test/alchemist-phoenix-test.el
@@ -1,4 +1,4 @@
-;;; alchemist-phoenix-test.el ---
+;;; alchemist-phoenix-test.el --- Summary
 
 ;; Copyright © 2014-2017 Samuel Tonini
 ;;
@@ -34,3 +34,4 @@
    (should-not (alchemist-phoenix-project-p))))
 
 (provide 'alchemist-phoenix-test)
+;;; alchemist-phoenix-test.el ends here

--- a/test/alchemist-phoenix-test.el
+++ b/test/alchemist-phoenix-test.el
@@ -25,14 +25,12 @@
 
 (ert-deftest alchemist-phoenix-test/a-phoenix-project ()
   (with-sandbox
-   (f-touch "mix.exs")
-   (f-mkdir "web")
+   (f-write "{:phoenix, \"~> 1.3.4\"}" 'utf-8 "mix.exs")
    (should (alchemist-phoenix-project-p))))
 
 (ert-deftest alchemist-phoenix-test/no-phoenix-project ()
   (with-sandbox
-   (f-touch "mix.exs")
-   (f-mkdir "lib")
+   (f-write "{:cowboy, \"~> 1.0\"}" 'utf-8 "mix.exs")
    (should-not (alchemist-phoenix-project-p))))
 
 (provide 'alchemist-phoenix-test)


### PR DESCRIPTION
Hello! :wave:

I noticed that modern phoenix projects no longer have a `web` directory, opting instead for a `lib/<project_name>_web` directory. This is mentioned in passing on the ["Up and Running" page for Phoenix](https://hexdocs.pm/phoenix/up_and_running.html#content). Since `alchemist-phoenix-project-p` looks for a project-root "web" directory, it was failing to detect my phoenix projects.

I figured it would be difficult to ascertain the name of the project in order to check for a `lib/<project_name>_web` directory explicitly, I opted instead to check whether the string ":phoenix" occurs in the `mix.exs` file of the project. This would be expected in the dependencies section of that file.

We could, alternately, check for the existence of a `lib/*_web` directory. I'm totally open to feedback on this! :smile: