### PR TITLE
Add quote to list of symbols

### DIFF
--- a/alchemist-goto.el
+++ b/alchemist-goto.el
@@ -58,10 +58,10 @@
 (defvar alchemist-goto-callback nil)
 
 (defconst alchemist-goto--symbol-def-extract-regex
-  "^\\s-*\\(defp?\\|defmacrop?\\|quote\\|defmodule\\|defimpl\\)[ \n\t]+\\([a-z_\?!]+\\)\\(.*\\)\\(do\\|\n\\)?$")
+  "^\\s-*\\(defp?\\|defmacrop?\\|quote\\|defmodule\\|defimpl\\|cond\\)[ \n\t]+\\([a-z_\?!]+\\)\\(.*\\)\\(do\\|\n\\)?$")
 
 (defconst alchemist-goto--symbol-def-regex
-  "^[[:space:]]*\\(defmodule\\|defmacrop?\\|quote\\|defimpl\\|defp?\\)")
+  "^[[:space:]]*\\(defmodule\\|defmacrop?\\|quote\\|defimpl\\|defp?\\|cond\\)")
 
 ;; Faces
 

--- a/alchemist-goto.el
+++ b/alchemist-goto.el
@@ -58,10 +58,10 @@
 (defvar alchemist-goto-callback nil)
 
 (defconst alchemist-goto--symbol-def-extract-regex
-  "^\\s-*\\(defp?\\|defmacrop?\\|defmodule\\|defimpl\\)[ \n\t]+\\([a-z_\?!]+\\)\\(.*\\)\\(do\\|\n\\)?$")
+  "^\\s-*\\(defp?\\|defmacrop?\\|quote\\|defmodule\\|defimpl\\)[ \n\t]+\\([a-z_\?!]+\\)\\(.*\\)\\(do\\|\n\\)?$")
 
 (defconst alchemist-goto--symbol-def-regex
-  "^[[:space:]]*\\(defmodule\\|defmacrop?\\|defimpl\\|defp?\\)")
+  "^[[:space:]]*\\(defmodule\\|defmacrop?\\|quote\\|defimpl\\|defp?\\)")
 
 ;; Faces
 


### PR DESCRIPTION
since ‘quote’ can start a block of code, it should be matched with things like `def`,`defmacro`,`defp`, etc.