### PR TITLE
Properly bind prefix key commands in alchemist-iex-mode-map

### DIFF
--- a/alchemist-iex.el
+++ b/alchemist-iex.el
@@ -60,14 +60,16 @@ iex(1)>
   "Hook for customizing `alchemist-iex-mode'.")
 
 (defvar alchemist-iex-mode-map
-  (let ((map (nconc (make-sparse-keymap) comint-mode-map)))
+  (let ((map (make-sparse-keymap))
+        (submap (make-sparse-keymap)))
     (define-key map "\t" 'company-complete)
     (define-key map (kbd "TAB") 'company-complete)
-    (define-key map (kbd (format "%s i r" alchemist-key-command-prefix)) 'alchemist-iex-open-input-ring)
-    (define-key map (kbd (format "%s i c" alchemist-key-command-prefix)) 'alchemist-iex-clear-buffer)
-    (define-key map (kbd (format "%s h e" alchemist-key-command-prefix)) 'alchemist-help-search-at-point)
+    (define-key submap (kbd "i r") 'alchemist-iex-open-input-ring)
+    (define-key submap (kbd "i c") 'alchemist-iex-clear-buffer)
+    (define-key submap (kbd "h e") 'alchemist-help-search-at-point)
     (define-key map (kbd "M-.") 'alchemist-goto-definition-at-point)
-    map))
+    (define-key map alchemist-key-command-prefix submap)
+    (make-composed-keymap map comint-mode-map)))
 
 (define-derived-mode alchemist-iex-mode comint-mode "Alchemist-IEx"
   "Major mode for interacting with an Elixir IEx process.


### PR DESCRIPTION
Hello, I set `alchemist-key-command-prefix` to `(kbd "C-,")`, and it turns out that the implementation in the master branch may not properly bind some keys in `alchemist-iex-mode-map`. With the config described above, some of the keybindings look like `[67108908]ir`, which is awkward. This PR fixes the issue.