### PR TITLE
Fix missing output from test report

### DIFF
--- a/alchemist-report.el
+++ b/alchemist-report.el
@@ -95,6 +95,7 @@ Argument for the exit function is the STATUS and BUFFER of the finished process.
 
 (defun alchemist-report-filter (process output)
   "Process filter for report buffers."
+  (display-buffer (process-buffer process))
   (with-current-buffer (process-buffer process)
     (let* ((buffer-read-only nil)
            (output (if (string= (process-name process) alchemist-test-report-process-name)


### PR DESCRIPTION
For some reason, on my machine the current `alchemist-report-filter` "skips" some output, including complete error messages and tests summaries.

Despite my lack of knowledge on Elisp, I've come to the conclusion that this happens because the process output is being buffered, and the `display-buffer` line on this PR solves the issue.

A more detailed description of this issue can be found at #357.

Closes #357.