### PR TITLE
Multi line alias expressions plus allowing modules to be named with leading colon

### DIFF
--- a/alchemist-project.el
+++ b/alchemist-project.el
@@ -117,8 +117,8 @@ directory from there instead."
   "Return the file which are tested by FILE.
 DIRECTORY is the place where the file under test is located."
   (let* ((filename (file-relative-name file (alchemist-project-root)))
-         (filename (replace-regexp-in-string "^test" directory filename))
-         (filename (replace-regexp-in-string "_test\.exs$" "\.ex" filename)))
+         (filename (replace-regexp-in-string "_test\.exs$" "\.ex" filename))
+         (filename (replace-regexp-in-string "test" directory filename)))
     (concat (alchemist-project-root) filename)))
 
 (defun alchemist-project-open-file-for-current-tests (opener)

--- a/alchemist-scope.el
+++ b/alchemist-scope.el
@@ -33,7 +33,7 @@
   :prefix "alchemist-scope-"
   :group 'alchemist)
 
-(defconst alchemist-scope-defmodule-regex "defmodule \\([A-Z][A-Za-z0-9\._]+\\)\s+"
+(defconst alchemist-scope-defmodule-regex "defmodule \\([A-Z:][A-Za-z0-9\._]+\\)\s+"
   "The regex for matching Elixir defmodule macro.")
 
 (defconst alchemist-scope-alias-regex
@@ -43,7 +43,7 @@
    alias Phoenix.Router.Resource, as: Special")
 
 (defconst alchemist-scope-alias-regex-two
-  "^\s+alias\s+\\([-:_A-Za-z0-9,\.\?!\]+\\)\.{\\([-:_A-Za-z0-9\s,\.\?!\]+\\)}\n"
+  "^\s+alias\s+\\([-:_A-Za-z0-9,\.\?!\]+\\)\.{\\([\n-:_A-Za-z0-9\s,\.\?!\]+\\)}\n"
   "The regex for matching Elixir alias definitions.
    Example:
    alias List.Chars.{Atom, Float}")
@@ -123,7 +123,7 @@
                  (not (alchemist-scope-inside-string-p))
                  (equal context (alchemist-scope-module)))
             (let* ((prefix (match-string 1))
-                   (alias-collection (if (match-string 2) (split-string (match-string 2) ",") nil)))
+                   (alias-collection (if (match-string 2) (split-string (replace-regexp-in-string "\n" "" (match-string 2)) ",") nil)))
               (-map (lambda (alias)
                       (let* ((alias (replace-regexp-in-string "\s+" "" alias))
                              (namespace (format "%s.%s" prefix alias)))


### PR DESCRIPTION
We have product that needs to deal with Erlang's common test framework. Modules need to be named "Erlang way", so I added rule to allow modules to be named with leading colon.

Second change is support for multi line alias expressions, such as:

alias MyModule.SubModule.{
  SomeOtherModule,
  AndAnotherOne
}