### PR TITLE
Document adding Alchemist to elixir-mode-hook

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -117,3 +117,9 @@ through the variable.
 ```el
 (setq alchemist-hooks-compile-on-save t)
 ```
+
+* Start Alchemist minor mode automatically with elixir-mode when opening .ex or .exs files
+
+```el
+(add-hook 'elixir-mode-hook 'alchemist-mode)
+```


### PR DESCRIPTION
Add new section to docs showing how to add Alchemist to elixir-mode
as a minor mode hook

This should resolve issue 260 https://github.com/tonini/alchemist.el/issues/260
