### PR TITLE
Fix String deprecated methods

### DIFF
--- a/alchemist-server/lib/helpers/complete.exs
+++ b/alchemist-server/lib/helpers/complete.exs
@@ -17,7 +17,7 @@ defmodule Alchemist.Helpers.Complete do
 
   def run(exp) do
     code = case is_bitstring(exp) do
-             true -> exp |> String.to_char_list
+             true -> exp |> String.to_charlist
              _ -> exp
            end
 
@@ -98,7 +98,7 @@ defmodule Alchemist.Helpers.Complete do
   end
 
   defp yes(hint, entries) do
-    {:yes, String.to_char_list(hint), Enum.map(entries, &String.to_char_list/1)}
+    {:yes, String.to_char_list(hint), Enum.map(entries, &String.to_charlist/1)}
   end
 
   defp no do

--- a/alchemist-server/lib/server/io.exs
+++ b/alchemist-server/lib/server/io.exs
@@ -24,6 +24,6 @@ defmodule Alchemist.Server.IO do
   end
 
   def read_line do
-    IO.gets("") |> String.rstrip()
+    IO.gets("") |> String.trim_trailing()
   end
 end

--- a/alchemist-server/lib/server/socket.exs
+++ b/alchemist-server/lib/server/socket.exs
@@ -40,7 +40,7 @@ defmodule Alchemist.Server.Socket do
       data when is_binary(data) ->
 
         data
-        |> String.strip
+        |> String.trim
         |> ProcessCommands.process(env)
         |> write_line(socket)
 


### PR DESCRIPTION
| Emacs | 27.0.50 build 10|
|:--|:--|
| Elixir | 1.8.1-otp-21 |
| `M-x alchemist-version` | Alchemist version: 1.8.2 |

When I run `alchemist-mix` (<kbd>C-C a x</kbd>), I got some warnings like this

![スクリーンショット 2019-08-15 22 11 37](https://user-images.githubusercontent.com/17716649/63235787-fb9f6400-c275-11e9-93e1-90571f1163e0.png)

This patch changes as bellow.

* Use String.trim/1 instead of String.strip/1
* Use String.trim_trailing/1 instead of String.rstrip/1
* Use String.to_charlist/1 instead of String.to_char_list/1