### PR TITLE
Make company-mode optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alchemist comes with a bunch of **features**, which are:
 * Smart code completion
 * Elixir project management
 * Phoenix support
-* Integration with [company-mode](http://company-mode.github.io/)
+* Optional integration with [company-mode](http://company-mode.github.io/)
 
 ***
 

--- a/alchemist-complete.el
+++ b/alchemist-complete.el
@@ -29,7 +29,7 @@
 (require 'dash)
 (require 's)
 (require 'ansi-color)
-(require 'company-dabbrev-code)
+(require 'company-dabbrev-code nil t)
 (require 'alchemist-utils)
 
 (defgroup alchemist-complete nil

--- a/alchemist-iex.el
+++ b/alchemist-iex.el
@@ -26,7 +26,7 @@
 ;;; Code:
 
 (require 'comint)
-(require 'company)
+(require 'company nil t)
 (require 'alchemist-key)
 (require 'alchemist-scope)
 (require 'alchemist-project)
@@ -61,8 +61,9 @@ iex(1)>
 
 (defvar alchemist-iex-mode-map
   (let ((map (nconc (make-sparse-keymap) comint-mode-map)))
-    (define-key map "\t" 'company-complete)
-    (define-key map (kbd "TAB") 'company-complete)
+    (when (featurep 'company)
+      (define-key map "\t" 'company-complete)
+      (define-key map (kbd "TAB") 'company-complete))
     (define-key map (kbd (format "%s i r" alchemist-key-command-prefix)) 'alchemist-iex-open-input-ring)
     (define-key map (kbd (format "%s i c" alchemist-key-command-prefix)) 'alchemist-iex-clear-buffer)
     (define-key map (kbd (format "%s h e" alchemist-key-command-prefix)) 'alchemist-help-search-at-point)

--- a/alchemist.el
+++ b/alchemist.el
@@ -59,7 +59,6 @@
 (defvar alchemist-mode-keymap nil)
 
 (require 'easymenu)
-(require 'company)
 (require 'elixir-mode)
 (require 'alchemist-utils)
 (require 'alchemist-key)
@@ -75,9 +74,11 @@
 (require 'alchemist-compile)
 (require 'alchemist-refcard)
 (require 'alchemist-complete)
-(require 'alchemist-company)
 (require 'alchemist-macroexpand)
 (require 'alchemist-phoenix)
+
+(when (require 'company nil t)
+  (require 'alchemist-company))
 
 (defun alchemist-mode-hook ()
   "Hook which enables `alchemist-mode'"


### PR DESCRIPTION
It seems that alchemist-mode works fine (other than the completion functionality) without having company installed; these patches allow it to work with no dependencies.